### PR TITLE
Clean and Clear CI Output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
 - contrib/configure.sh
 
 script:
-- make lint package index
+- make clean lint package index
 
 before_deploy:
 - |-

--- a/Makefile.library
+++ b/Makefile.library
@@ -1,3 +1,8 @@
+.PHONY : clean
+clean:
+	@find . -maxdepth 3 -mindepth 3 -type f -name '*.tgz' -delete
+
+.PHONY : lint
 lint:
 	@echo "## Linting charts $(shell pwd)"
 	@find . -maxdepth 1 -mindepth 1 -type d | \

--- a/Makefile.packages
+++ b/Makefile.packages
@@ -11,10 +11,6 @@ index:
 	@echo "## Generating index for $(REPO_URL)"
 	@helm repo index . --url $(REPO_URL) --debug
 
-.PHONY : real-clean
-real-clean: clean
-	rm -f *.tgz
-
 .PHONY : clean
 clean:
-	rm -f index.yaml
+	@rm -f index.yaml *.tgz

--- a/Makefile.repo
+++ b/Makefile.repo
@@ -20,7 +20,5 @@ index:
 .PHONY : clean
 clean:
 	@rm -f *.tgz
-  
-.PHONY : real-clean
-real-clean: clean
+	@make -C library/ $@
 	@make -C packages/ $@


### PR DESCRIPTION
## what
* format output to make it easier to identify where failures happen
* run `make clean` to ensure no packages are cached from previous builds

## why
* spent too much time figuring it out
* ci should have prevented this: https://github.com/cloudposse/charts/pull/31


## example
```
# Updating dependencies for library/kube-lego
No requirements found in /Users/e/Dropbox/Dev/cloudposse/charts/incubator/library/kube-lego/charts.

# Updating dependencies for library/kubernetes-dashboard
No requirements found in /Users/e/Dropbox/Dev/cloudposse/charts/incubator/library/kubernetes-dashboard/charts.

# Updating dependencies for library/nginx-default-backend
No requirements found in /Users/e/Dropbox/Dev/cloudposse/charts/incubator/library/nginx-default-backend/charts.

# Updating dependencies for library/nginx-ingress
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "cloudposse-stable" chart repository
...Successfully got an update from the "kubernetes-charts" chart repository
...Successfully got an update from the "stable" chart repository
...Successfully got an update from the "cloudposse-incubator" chart repository
Update Complete. ⎈Happy Helming!⎈
Saving 1 charts
Downloading nginx-default-backend from repo https://charts.cloudposse.com/incubator
Error: could not find : no matching version

# Updating dependencies for library/postfix
No requirements found in /Users/e/Dropbox/Dev/cloudposse/charts/incubator/library/postfix/charts.
```

## who
@goruha 