### PR TITLE
Bump Nginx Ingress Default Backend Version Requirement to 0.2.1

### DIFF
--- a/incubator/library/nginx-ingress/requirements.yaml
+++ b/incubator/library/nginx-ingress/requirements.yaml
@@ -1,5 +1,5 @@
 # requirements.yaml
 dependencies:
 - name: "nginx-default-backend"
-  version: "0.2.0"
+  version: "0.2.1"
   repository: "https://charts.cloudposse.com/incubator"


### PR DESCRIPTION
## what
* Bump version to 0.2.1

## why
* Forgot to in PR#29

## who
@goruha 