### PR TITLE
Add label to differentiate exposed nginx-ingress service with nginx default backend

### DIFF
--- a/incubator/library/nginx-ingress/Chart.yaml
+++ b/incubator/library/nginx-ingress/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: nginx-ingress
-version: 0.1.1
+version: 0.1.2

--- a/incubator/library/nginx-ingress/templates/service.yaml
+++ b/incubator/library/nginx-ingress/templates/service.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     k8s-addon: ingress-nginx.addons.k8s.io
+    role: entrypoint
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}
 spec:

--- a/incubator/library/route53-kubernetes/values.yaml
+++ b/incubator/library/route53-kubernetes/values.yaml
@@ -1,7 +1,7 @@
 # Default values for route53-kubernetes.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-ingress_service_selector: k8s-addon=ingress-nginx.addons.k8s.io
+ingress_service_selector: k8s-addon=ingress-nginx.addons.k8s.io,role=entrypoint
 dns_record_type: CNAME
 dns_record_ttl: 300
 


### PR DESCRIPTION
## what
* Add a label `role=entrypoint` to the `nginx-ingress` service to denote that's the client endpoint

## why
* Because with PR https://github.com/cloudposse/charts/pull/29, we have the same labels for ingress-nginx service (that is external) and ingress-nginx-default service - we can not make route53 select right one

## who
@cloudposse/engineering 