### PR TITLE
Use Friendly Error Pages for 502 and 504 HTTP Status Codes

### DIFF
--- a/incubator/library/nginx-default-backend/templates/configmap.yaml
+++ b/incubator/library/nginx-default-backend/templates/configmap.yaml
@@ -18,8 +18,20 @@ data:
         }
 
         location / {
+          if ($http_x_code =  "500" ) {
+            return 500;
+          }
+
+          if ($http_x_code =  "502" ) {
+            return 502;
+          }
+
           if ($http_x_code =  "503" ) {
             return 503;
+          }
+
+          if ($http_x_code =  "504" ) {
+            return 504;
           }
           return 404;
         }
@@ -30,7 +42,7 @@ data:
                 internal;
         }
 
-        error_page 503 /50x.html;
+        error_page 500 502 503 504 /50x.html;
         location = /50x.html {
                 root /usr/share/nginx/html;
                 internal;

--- a/incubator/library/nginx-ingress/templates/configmap.yaml
+++ b/incubator/library/nginx-ingress/templates/configmap.yaml
@@ -6,6 +6,6 @@ metadata:
     k8s-addon: ingress-nginx.addons.k8s.io
 data:
   use-proxy-protocol: "true"
-  custom-http-errors: 404,503
+  custom-http-errors: 404,502,503,504
 
 


### PR DESCRIPTION
## what
* Return friendly status pages for 502 and 504 HTTP status codes

## why
* Looks more professional
* Provide a way for users to contact admin

## who
@cloudposse/engineering 