### PR TITLE
LAMP Chart Should Use HTTP Headers in Health Check

### DIFF
--- a/incubator/lamp/Chart.yaml
+++ b/incubator/lamp/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Linux, Apache, MySQL, PHP (aka LAMP)
 name: lamp
-version: 0.1.1
+version: 0.1.2

--- a/incubator/lamp/requirements.yaml
+++ b/incubator/lamp/requirements.yaml
@@ -1,7 +1,7 @@
 # requirements.yaml
 dependencies:
 - name: "apache"
-  version: "0.1.2"
+  version: "0.1.3"
   repository: "https://charts.cloudposse.com/incubator"
 - name: "vps"
   version: "0.1.0"

--- a/incubator/lamp/values.yaml
+++ b/incubator/lamp/values.yaml
@@ -128,6 +128,9 @@ apache:
     fall: 3           # Number of unsuccessful requests before service is considered unhealthy
     interval: 10      # How often to check the service (seconds)
     timeout: 1        # Acceptable amount of time for a request to complete (seconds)
+    headers: 
+      - name: Host
+        value: localhost
 
   mounts:
     # Volume name must match the regex [a-z0-9]([-a-z0-9]*[a-z0-9])? (e.g. 'my-name' or '123-abc')


### PR DESCRIPTION
## what
* Leverage HTTP Headers in Healthcheck

## why
* Make apps like Wordpress happy 

## who
@cloudposse/engineering 