### PR TITLE
Varnish Should Respect the X-Forwarded-Proto Header for Non-static Assets

### DIFF
--- a/incubator/varnish/Chart.yaml
+++ b/incubator/varnish/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart Varnish running under Kubernetes
 name: varnish
-version: 0.1.0
+version: 0.1.1

--- a/incubator/varnish/templates/configmap.yaml
+++ b/incubator/varnish/templates/configmap.yaml
@@ -98,10 +98,15 @@ data:
       sub vcl_hash {
         hash_data(req.url);
         if (req.http.host) {
-            hash_data(req.http.host);
+          hash_data(req.http.host);
         } else {
-            hash_data(server.ip);
+          hash_data(server.ip);
         }
+
+        if (req.http.X-Forwarded-Proto && req.url !~ "(?i)\.(png|gif|jpeg|jpg|ico|gz|tgz|bz2|tbz|mp3|ogg|zip|rar|otf|ttf|eot|woff|svg|pdf)$") {
+          hash_data(req.http.X-Forwarded-Proto);
+        }
+
         return (lookup);
       }
 
@@ -398,11 +403,17 @@ data:
 
       sub vcl_hash {
         hash_data(req.url);
+
         if (req.http.host) {
-            hash_data(req.http.host);
+          hash_data(req.http.host);
         } else {
-            hash_data(server.ip);
+          hash_data(server.ip);
         }
+
+        if (req.http.X-Forwarded-Proto && req.url !~ "(?i)\.(png|gif|jpeg|jpg|ico|gz|tgz|bz2|tbz|mp3|ogg|zip|rar|otf|ttf|eot|woff|svg|pdf)$") {
+          hash_data(req.http.X-Forwarded-Proto);
+        }
+
         return (lookup);
       }
 


### PR DESCRIPTION
## what
*  Add `X-Forwarded-Proto` as a hash key for non-static assets

## why
* HTTPS content should use `https://` for all resources. Unless we use `X-Forwarded-Proto` as a factor for how we cache, the content may contain `http://` URLs.

## who
@goruha 