### PR TITLE
Add support for defining custom HTTP error codes

### DIFF
--- a/incubator/lamp/templates/_helpers.tpl
+++ b/incubator/lamp/templates/_helpers.tpl
@@ -15,6 +15,12 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/*
+Apache host
+*/}}
+{{- define "apache_fullname" -}}
+{{- printf "%s-%s" .Release.Name "apache" | trunc 24 | trimSuffix "-" -}}
+{{- end -}}
 
 {{/*
 Mysql host

--- a/incubator/lamp/templates/ingress.yaml
+++ b/incubator/lamp/templates/ingress.yaml
@@ -25,6 +25,6 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: {{template "fullname" . }}
+          serviceName: {{template "apache_fullname" . }}
           servicePort: {{.Values.apache.service.externalPort}}
 {{- end }}

--- a/incubator/nginx-default-backend/templates/configmap.yaml
+++ b/incubator/nginx-default-backend/templates/configmap.yaml
@@ -18,38 +18,34 @@ data:
         }
 
         location / {
-          if ($http_x_code =  "500" ) {
-            return 500;
+          {{ range $index, $element := .Values.errors.server }}
+          if ($http_x_code =  {{ $element | quote }} ) {
+            return {{ $element }};
           }
+          {{ end }}
 
-          if ($http_x_code =  "502" ) {
-            return 502;
+          {{ range $index, $element := .Values.errors.client }}
+          if ($http_x_code =  {{ $element | quote }} ) {
+            return {{ $element }};
           }
+          {{ end }}
 
-          if ($http_x_code =  "503" ) {
-            return 503;
-          }
-
-          if ($http_x_code =  "504" ) {
-            return 504;
-          }
           return 404;
         }
 
-        error_page 404 /404.html;
+        error_page {{ range $index, $element := .Values.errors.client }} {{$element}} {{end}} /404.html;
         location = /404.html {
                 root /usr/share/nginx/html;
                 internal;
         }
 
-        error_page 500 502 503 504 /50x.html;
+        error_page  {{ range $index, $element := .Values.errors.server }} {{$element}} {{end}} /50x.html;
         location = /50x.html {
                 root /usr/share/nginx/html;
                 internal;
         }
     }
-
-{{- if eq .Values.errors.configmap "default" }}
+{{ if eq .Values.errors.configmap "default" }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/incubator/nginx-default-backend/values.yaml
+++ b/incubator/nginx-default-backend/values.yaml
@@ -23,3 +23,10 @@ errors:
   default:
     email: hello@cloudposse.com
     site: http://cloudposse.com
+  client:
+    - "404"
+  server:
+    - "500"
+    - "502"
+    - "503"
+    - "504"

--- a/incubator/nginx-ingress/Chart.yaml
+++ b/incubator/nginx-ingress/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
-description: A Helm chart for Kubernetes
+description: A Helm chart for Nginx Ingress
 name: nginx-ingress
-version: 0.1.2
+version: 0.1.3

--- a/incubator/nginx-ingress/templates/configmap.yaml
+++ b/incubator/nginx-ingress/templates/configmap.yaml
@@ -6,6 +6,14 @@ metadata:
     k8s-addon: ingress-nginx.addons.k8s.io
 data:
   use-proxy-protocol: "true"
-{{- if .Values.customHttpErrors }}
-  custom-http-errors: "{{ range $index, $element := .Values.customHttpErrors}}{{if $index}}, {{end}}{{$element}}{{end}}"
-{{- end }}
+  custom-http-errors: "
+    {{- range $index, $element := .Values.customHttpErrors.client -}}
+      {{ if $index }},{{ end }}{{ $element }}
+    {{- end -}}
+    {{- if and ( not ( empty .Values.customHttpErrors.client ) ) ( not ( empty .Values.customHttpErrors.server ) ) -}}
+    ,
+    {{- end -}}
+    {{- range $index, $element := .Values.customHttpErrors.server -}}
+      {{ if $index }},{{ end }}{{ $element }}
+    {{- end -}}
+  "

--- a/incubator/nginx-ingress/templates/configmap.yaml
+++ b/incubator/nginx-ingress/templates/configmap.yaml
@@ -6,6 +6,6 @@ metadata:
     k8s-addon: ingress-nginx.addons.k8s.io
 data:
   use-proxy-protocol: "true"
-  custom-http-errors: 404,502,503,504
-
-
+{{- if .Values.customHttpErrors }}
+  custom-http-errors: "{{ range $index, $element := .Values.customHttpErrors}}{{if $index}}, {{end}}{{$element}}{{end}}"
+{{- end }}

--- a/incubator/nginx-ingress/values.yaml
+++ b/incubator/nginx-ingress/values.yaml
@@ -1,11 +1,22 @@
 # Default values for nginx-ingress.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+
 replicaCount: 1
+
+# Error codes that we should intercept in order to display a pretty error page
+customHttpErrors:
+  - "404"
+  - "500"
+  - "502"
+  - "503"
+  - "504"
+
 image:
   repository: "gcr.io/google_containers/nginx-ingress-controller"
   tag: "0.8.3"
   pullPolicy: "IfNotPresent"
+
 service:
   name: nginx
   type: LoadBalancer
@@ -16,6 +27,7 @@ service:
   internalHealthzPort: 18080
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: '*'
+
 resources:
   limits:
     cpu: 100m

--- a/incubator/nginx-ingress/values.yaml
+++ b/incubator/nginx-ingress/values.yaml
@@ -4,14 +4,6 @@
 
 replicaCount: 1
 
-# Error codes that we should intercept in order to display a pretty error page
-customHttpErrors:
-  - "404"
-  - "500"
-  - "502"
-  - "503"
-  - "504"
-
 image:
   repository: "gcr.io/google_containers/nginx-ingress-controller"
   tag: "0.8.3"
@@ -36,3 +28,43 @@ resources:
     cpu: 100m
     memory: 128Mi
 
+# Error codes that we should intercept in order to display a pretty error page
+customHttpErrors:
+  client:
+    - "404"
+  server:
+    - "500"
+    - "502"
+    - "503"
+    - "504"
+
+nginx-default-backend:
+  replicaCount: 1
+  image:
+    repository: nginx
+    tag: alpine
+    pullPolicy: IfNotPresent
+  service:
+    name: nginx
+    type: ClusterIP
+    externalPort: 80
+    internalPort: 8080
+  resources:
+    limits:
+      cpu: 10m
+      memory: 20Mi
+    requests:
+      cpu: 10m
+      memory: 20Mi
+  errors:
+    configmap: default
+    default:
+      email: hello@cloudposse.com
+      site: http://cloudposse.com
+    client:
+      - "404"
+    server:
+      - "500"
+      - "502"
+      - "503"
+      - "504"


### PR DESCRIPTION
## what
* allow `custom-error-codes` to be defined in `values.yaml`

## why
* some applications might already generate nice status pages
* other times we might want to intercept more status codes (e.g. `500` and `502`)

## who
@goruha 