### PR TITLE
Add Support for Authenticated SMTP Relay Host

### DIFF
--- a/incubator/postfix/templates/deployment.yaml
+++ b/incubator/postfix/templates/deployment.yaml
@@ -11,7 +11,7 @@ spec:
       labels:
         app: {{ template "fullname" . }}
       annotations:
-        checksum/secret: {{ include (print $.Chart.Name "/templates/secret.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Chart.Name "/templates/secrets.yaml") . | sha256sum }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/incubator/postfix/templates/deployment.yaml
+++ b/incubator/postfix/templates/deployment.yaml
@@ -41,6 +41,8 @@ spec:
             secretKeyRef:
               name: {{ template "fullname" . }}
               key: smtp_domain
+        - name: RELAY_AUTH_ENABLED
+          value: {{ .Values.smtp.relay.enabled | quote }} 
 {{- if .Values.smtp.relay.enabled }}
         - name: RELAY_AUTH_TLS
           valueFrom:

--- a/incubator/postfix/templates/deployment.yaml
+++ b/incubator/postfix/templates/deployment.yaml
@@ -43,7 +43,10 @@ spec:
               key: smtp_domain
 {{- if .Values.smtp.relay.enabled }}
         - name: RELAY_AUTH_ENABLED
-          value: "true"
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}
+              key: smtp_relay_enabled
         - name: RELAY_AUTH_TLS
           valueFrom:
             secretKeyRef:

--- a/incubator/postfix/templates/deployment.yaml
+++ b/incubator/postfix/templates/deployment.yaml
@@ -44,6 +44,11 @@ spec:
 {{- if .Values.smtp.relay.enabled }}
         - name: RELAY_AUTH_ENABLED
           value: "true"
+        - name: RELAY_AUTH_TLS
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}
+              key: smtp_relay_tls
         - name: RELAYHOST
           valueFrom:
             secretKeyRef:

--- a/incubator/postfix/templates/deployment.yaml
+++ b/incubator/postfix/templates/deployment.yaml
@@ -42,11 +42,6 @@ spec:
               name: {{ template "fullname" . }}
               key: smtp_domain
 {{- if .Values.smtp.relay.enabled }}
-        - name: RELAY_AUTH_ENABLED
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "fullname" . }}
-              key: smtp_relay_enabled
         - name: RELAY_AUTH_TLS
           valueFrom:
             secretKeyRef:

--- a/incubator/postfix/templates/deployment.yaml
+++ b/incubator/postfix/templates/deployment.yaml
@@ -10,17 +10,22 @@ spec:
     metadata:
       labels:
         app: {{ template "fullname" . }}
+      annotations:
+        checksum/secret: {{ include (print $.Chart.Name "/templates/secret.yaml") . | sha256sum }}
     spec:
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
+{{- range $name, $value := .Values.env }}
+{{- if not (empty $value) }}
+        - name: {{ $name | quote }}
+          value: {{ $value | quote }}
+{{- end }}
+{{- end }}
         - name: POSTMASTER_USER
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "fullname" . }}
-              key: smtp_username
+          value: "postmaster"
         - name: POSTMASTER_PASS
           valueFrom:
             secretKeyRef:
@@ -31,6 +36,35 @@ spec:
             secretKeyRef:
               name: {{ template "fullname" . }}
               key: smtp_domain
+        - name: MAILNAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}
+              key: smtp_domain
+{{- if .Values.smtp.relay.enabled }}
+        - name: RELAY_AUTH_ENABLED
+          value: "true"
+        - name: RELAYHOST
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}
+              key: smtp_relay_host
+        - name: RELAY_AUTH_DOMAIN
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}
+              key: smtp_relay_domain
+        - name: RELAY_AUTH_USER
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}
+              key: smtp_relay_user
+        - name: RELAY_AUTH_PASS
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}
+              key: smtp_relay_password
+{{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:
@@ -43,3 +77,5 @@ spec:
           initialDelaySeconds: 10
         resources:
 {{ toYaml .Values.resources | indent 12 }}
+
+

--- a/incubator/postfix/templates/secrets.yaml
+++ b/incubator/postfix/templates/secrets.yaml
@@ -11,10 +11,11 @@ type: Opaque
 data:
   smtp_password : {{ trim .Values.smtp.password | b64enc }}
   smtp_domain: {{ trim .Values.smtp.domain | b64enc }}
-  smtp_relay_enabled: {{ .Values.smtp.relay.enabled | b64enc }}
+{{- if .Values.smtp.relay.enabled }}
   smtp_relay_host: {{ cat "[" ( default "" .Values.smtp.relay.host) "]:" .Values.smtp.relay.port | replace " " "" | trim | b64enc }}
   smtp_relay_domain: {{ default "" .Values.smtp.relay.host | trim | b64enc }}
   smtp_relay_tls: {{ .Values.smtp.relay.tls | b64enc }}
   smtp_relay_user: {{ default "" .Values.smtp.relay.user | trim | b64enc }}
   smtp_relay_password: {{ default "" .Values.smtp.relay.password | trim | b64enc }}
+{{- end }}
 

--- a/incubator/postfix/templates/secrets.yaml
+++ b/incubator/postfix/templates/secrets.yaml
@@ -11,9 +11,9 @@ type: Opaque
 data:
   smtp_password : {{ trim .Values.smtp.password | b64enc }}
   smtp_domain: {{ trim .Values.smtp.domain | b64enc }}
-  smtp_relay_host: {{ cat "[" .Values.smtp.relay.host "]:" .Values.smtp.relay.port | replace " " "" | trim | b64enc }}
-  smtp_relay_domain: {{ trim .Values.smtp.relay.host | b64enc }}
-  smtp_relay_tls: {{ trim .Values.smtp.relay.tls | b64enc }}
-  smtp_relay_user: {{ trim .Values.smtp.relay.user | b64enc }}
-  smtp_relay_password: {{ trim .Values.smtp.relay.password | b64enc }}
+  smtp_relay_host: {{ cat "[" ( default "" .Values.smtp.relay.host) "]:" .Values.smtp.relay.port | replace " " "" | trim | b64enc }}
+  smtp_relay_domain: {{ default "" .Values.smtp.relay.host | trim | b64enc }}
+  smtp_relay_tls: {{ .Values.smtp.relay.tls | b64enc }}
+  smtp_relay_user: {{ default "" .Values.smtp.relay.user | trim | b64enc }}
+  smtp_relay_password: {{ default "" .Values.smtp.relay.password | trim | b64enc }}
 

--- a/incubator/postfix/templates/secrets.yaml
+++ b/incubator/postfix/templates/secrets.yaml
@@ -9,6 +9,10 @@ metadata:
     heritage: "{{ .Release.Service }}"
 type: Opaque
 data:
-  smtp_username: {{ trim .Values.smtp.username | b64enc }}
   smtp_password : {{ trim .Values.smtp.password | b64enc }}
   smtp_domain: {{ trim .Values.smtp.domain | b64enc }}
+  smtp_relay_host: {{ cat "[" .Values.smtp.relay.host "]:" .Values.smtp.relay.port | replace " " "" | trim | b64enc }}
+  smtp_relay_domain: {{ trim .Values.smtp.relay.host | b64enc }}
+  smtp_relay_user: {{ trim .Values.smtp.relay.user | b64enc }}
+  smtp_relay_password: {{ trim .Values.smtp.relay.password | b64enc }}
+

--- a/incubator/postfix/templates/secrets.yaml
+++ b/incubator/postfix/templates/secrets.yaml
@@ -11,6 +11,7 @@ type: Opaque
 data:
   smtp_password : {{ trim .Values.smtp.password | b64enc }}
   smtp_domain: {{ trim .Values.smtp.domain | b64enc }}
+  smtp_relay_enabled: {{ .Values.smtp.relay.enabled | b64enc }}
   smtp_relay_host: {{ cat "[" ( default "" .Values.smtp.relay.host) "]:" .Values.smtp.relay.port | replace " " "" | trim | b64enc }}
   smtp_relay_domain: {{ default "" .Values.smtp.relay.host | trim | b64enc }}
   smtp_relay_tls: {{ .Values.smtp.relay.tls | b64enc }}

--- a/incubator/postfix/templates/secrets.yaml
+++ b/incubator/postfix/templates/secrets.yaml
@@ -13,6 +13,7 @@ data:
   smtp_domain: {{ trim .Values.smtp.domain | b64enc }}
   smtp_relay_host: {{ cat "[" .Values.smtp.relay.host "]:" .Values.smtp.relay.port | replace " " "" | trim | b64enc }}
   smtp_relay_domain: {{ trim .Values.smtp.relay.host | b64enc }}
+  smtp_relay_tls: {{ trim .Values.smtp.relay.tls | b64enc }}
   smtp_relay_user: {{ trim .Values.smtp.relay.user | b64enc }}
   smtp_relay_password: {{ trim .Values.smtp.relay.password | b64enc }}
 

--- a/incubator/postfix/values.yaml
+++ b/incubator/postfix/values.yaml
@@ -12,7 +12,7 @@ smtp:
   domain: "cloudposse.local"
   password: "secret"
   relay:
-    enabled: false
+    enabled: "false"
     host:
     port:
     tls: "false"

--- a/incubator/postfix/values.yaml
+++ b/incubator/postfix/values.yaml
@@ -15,6 +15,7 @@ smtp:
     enabled: false
     host:
     port:
+    tls: false
     user:
     password:
 service:

--- a/incubator/postfix/values.yaml
+++ b/incubator/postfix/values.yaml
@@ -2,14 +2,21 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 replicaCount: 1
+env:
+#  SOME_VAR: SOME_VALUE
 image:
   repository: "cloudposse/postfix"
   tag: "latest"
   pullPolicy: Always
 smtp:
   domain: "cloudposse.local"
-  username: "postmaster"
   password: "secret"
+  relay:
+    enabled: false
+    host:
+    port:
+    user:
+    password:
 service:
   name: smtp
   type: ClusterIP

--- a/incubator/postfix/values.yaml
+++ b/incubator/postfix/values.yaml
@@ -15,7 +15,7 @@ smtp:
     enabled: false
     host:
     port:
-    tls: false
+    tls: "false"
     user:
     password:
 service:


### PR DESCRIPTION
## what
* Update configuration to support relay host

## why
* Secure relay to 3rd-party SMTP services like Mailgun or SES
* no need to expose provider credentials to internal apps (e.g. Wordpress) since they can be configured to use internal SMTP service
* Fault-tolerance - postfix will keep retrying until relay online

## who
@cloudposse/engineering 