### PR TITLE
Enable Support for `use-proxy-protocol`

### DIFF
--- a/incubator/nginx-ingress/Chart.yaml
+++ b/incubator/nginx-ingress/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Nginx Ingress
 name: nginx-ingress
-version: 0.1.3
+version: 0.1.4

--- a/incubator/nginx-ingress/templates/configmap.yaml
+++ b/incubator/nginx-ingress/templates/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     k8s-addon: ingress-nginx.addons.k8s.io
 data:
-  use-proxy-protocol: "true"
+  use-proxy-protocol: {{ .Values.proxy | quote }}
   custom-http-errors: "
     {{- range $index, $element := .Values.customHttpErrors.client -}}
       {{ if $index }},{{ end }}{{ $element }}

--- a/incubator/nginx-ingress/templates/configmap.yaml
+++ b/incubator/nginx-ingress/templates/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     k8s-addon: ingress-nginx.addons.k8s.io
 data:
-  use-proxy-protocol: {{ .Values.proxy | quote }}
+  use-proxy-protocol: {{ .Values.useProxyProtocol | quote }}
   custom-http-errors: "
     {{- range $index, $element := .Values.customHttpErrors.client -}}
       {{ if $index }},{{ end }}{{ $element }}

--- a/incubator/nginx-ingress/templates/deployment.yaml
+++ b/incubator/nginx-ingress/templates/deployment.yaml
@@ -11,7 +11,9 @@ spec:
     metadata:
       labels:
         app: {{ template "fullname" . }}
-        k8s-addon: {{ template "fullname" . }}.addons.k8s.io
+        k8s-addon: "{{ template "fullname" . }}.addons.k8s.io"
+      annotations:
+        checksum/config: {{ include (print $.Chart.Name "/templates/configmap.yaml") . | sha256sum }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/incubator/nginx-ingress/values.yaml
+++ b/incubator/nginx-ingress/values.yaml
@@ -28,6 +28,8 @@ resources:
     cpu: 100m
     memory: 128Mi
 
+proxy: true
+
 # Error codes that we should intercept in order to display a pretty error page
 customHttpErrors:
   client:

--- a/incubator/nginx-ingress/values.yaml
+++ b/incubator/nginx-ingress/values.yaml
@@ -28,7 +28,7 @@ resources:
     cpu: 100m
     memory: 128Mi
 
-proxy: true
+useProxyProtocol: true
 
 # Error codes that we should intercept in order to display a pretty error page
 customHttpErrors:


### PR DESCRIPTION
## what 
* Add support for `use-proxy-protocol`
* Make it configurable because  GCE LB does not support proxy protocol; If it is enabled on GCE - Ingress do not work.


## why
* If you are using a L4 proxy to forward the traffic to the NGINX pods and terminate HTTP/HTTPS there, you will lose the remote endpoint's IP addresses. To prevent this you could use the Proxy Protocol for forwarding traffic, this will send the connection details before forwarding the actual TCP connection itself. 
* https://github.com/kubernetes/contrib/tree/99cba026d6c42d08b944aae1fd9fac173d76e3a1/ingress/controllers/nginx#proxy-protocol

