### PR TITLE
Support Operator 0.7.0

### DIFF
--- a/incubator/alertmanager/Chart.yaml
+++ b/incubator/alertmanager/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: alertmanager
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.1.0
+version: 0.2.0

--- a/incubator/alertmanager/templates/_alertmanager.yaml.tpl
+++ b/incubator/alertmanager/templates/_alertmanager.yaml.tpl
@@ -1,0 +1,16 @@
+{{- if .Values.config }}
+{{ .Values.config }}
+{{- else }}
+global:
+  resolve_timeout: 5m
+receivers:
+  - name: 'webhook'
+    webhook_configs:
+      - url: 'http://alertmanagerwh:30500/'
+route:
+  group_by: ['job']
+  group_interval: 5m
+  group_wait: 30s
+  receiver: 'webhook'
+  repeat_interval: 12h
+{{- end }}

--- a/incubator/alertmanager/templates/secret.yaml
+++ b/incubator/alertmanager/templates/secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    alertmanager: {{ .Release.Name }}
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: alertmanager-{{ .Release.Name }}
+data:
+  alertmanager.yaml: {{ include (print  (dir $.Template.Name) "/_alertmanager.yaml.tpl") . | b64enc | quote }}

--- a/incubator/prometheus/Chart.yaml
+++ b/incubator/prometheus/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: prometheus
 sources:
   - https://github.com/coreos/prometheus-operator
-version: 0.1.0
+version: 0.2.0

--- a/incubator/prometheus/templates/_configmaps.json.tpl
+++ b/incubator/prometheus/templates/_configmaps.json.tpl
@@ -1,0 +1,8 @@
+{ "items": [
+{{- if and .Values.rules.specifiedInValues .Values.rules.value }}
+  {
+    "key": "{{ .Release.Namespace }}/prometheus-{{ .Release.Name }}-rules",
+    "checksum": "33bbd11f3d6ecfa14af3d46c46e91de4906fe86d2429f34ba6ee74082f9d6414"
+  }
+{{- end }}
+]}

--- a/incubator/prometheus/templates/prometheus.yaml
+++ b/incubator/prometheus/templates/prometheus.yaml
@@ -30,8 +30,22 @@ spec:
 {{- if .Values.routePrefix }}
   routePrefix: "{{ .Values.routePrefix }}"
 {{- end }}
-{{- if .Values.serviceMonitors }}
+{{- if .Values.serviceMonitorsSelector }}
   serviceMonitorSelector:
+    matchLabels:
+{{ toYaml .Values.serviceMonitorsSelector | indent 6 }}
+{{- else if  .Values.serviceMonitors }}
+  serviceMonitorSelector:
+    matchLabels:
+      app: {{ template "name" . }}
+      release: {{ .Release.Name }}
+{{- end }}
+{{- if .Values.rulesSelector }}
+  ruleSelector:
+    matchLabels:
+{{ toYaml .Values.rulesSelector | indent 6 }}
+{{- else if  .Values.rules.value }}
+  ruleSelector:
     matchLabels:
       app: {{ template "name" . }}
       release: {{ .Release.Name }}

--- a/incubator/prometheus/templates/rules.yaml
+++ b/incubator/prometheus/templates/rules.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rules.specifiedInValues -}}
+{{- if and .Values.rules.specifiedInValues .Values.rules.value }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,7 +8,8 @@ metadata:
     heritage: {{ .Release.Service }}
     prometheus: {{ .Release.Name }}
     release: {{ .Release.Name }}
+{{ toYaml .Values.rulesSelector | indent 4 }}
   name: prometheus-{{ .Release.Name }}-rules
 data:
 {{ toYaml .Values.rules.value | indent 2 }}
-{{- end -}}
+{{- end }}

--- a/incubator/prometheus/templates/secret.yaml
+++ b/incubator/prometheus/templates/secret.yaml
@@ -1,0 +1,15 @@
+{{- if and (and .Values.config.specifiedInValues .Values.config.value ) ( not .Values.serviceMonitorSelector ) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    prometheus: {{ .Release.Name }}
+    release: {{ .Release.Name }}
+{{ toYaml .Values.serviceMonitorsSelector | indent 4 }}
+  name: prometheus-{{ .Release.Name }}
+data:
+  prometheus.yaml: {{ toYaml .Values.config.value | b64enc | quote }}
+{{- end }}

--- a/incubator/prometheus/templates/secret.yaml
+++ b/incubator/prometheus/templates/secret.yaml
@@ -11,5 +11,6 @@ metadata:
 {{ toYaml .Values.serviceMonitorsSelector | indent 4 }}
   name: prometheus-{{ .Release.Name }}
 data:
+  configmaps.json: {{ include (print  (dir $.Template.Name) "/_configmaps.json.tpl") . | b64enc | quote }}
   prometheus.yaml: {{ toYaml .Values.config.value | b64enc | quote }}
 {{- end }}

--- a/incubator/prometheus/templates/servicemonitors.yaml
+++ b/incubator/prometheus/templates/servicemonitors.yaml
@@ -16,6 +16,7 @@ items:
         chart: {{ $chartName }}-{{ $chartVersion }}
         heritage: {{ $releaseService }}
         release: {{ $releaseName }}
+{{ toYaml .Values.serviceMonitorSelector | indent 8 }}
       name: {{ .name }}
     spec:
       endpoints:

--- a/incubator/prometheus/values.yaml
+++ b/incubator/prometheus/values.yaml
@@ -75,6 +75,11 @@ retention: 24h
 ##
 routePrefix: /
 
+## Rules configmap selector
+## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/design.md
+##
+rulesSelector: {}
+
 ## Prometheus alerting & recording rules
 ## Ref: https://prometheus.io/docs/querying/rules/
 ## Ref: https://prometheus.io/docs/alerting/rules/
@@ -114,6 +119,11 @@ service:
   ## Service type
   ##
   type: ClusterIP
+
+## Service monitors selector
+## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/design.md
+##
+serviceMonitorsSelector: {}
 
 ## ServiceMonitor TPRs to create & be scraped by the Prometheus instance.
 ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/service-monitor.md


### PR DESCRIPTION
## What
* Made alertmanager config stored in secret
* Made prometheus config stored in secret
* Added support for prometheus rules selector
* Added support to override prometheus configs in umbrella chart with resource ( not by values )
* Added support to override prometheus rules in umbrella chart with resource ( not by values )
* Added support to specify custom selector for prometheus ServiceMonitors
* Added support to specify custom selector for prometheus rules configs


## Why 
* Prometheus operator starting from version 0.7.0 use secrets to store configs
https://github.com/coreos/prometheus-operator/releases/tag/v0.7.0
* Provide flexible way to specify promethus config in umbrella chart resources (example you can find here #80 ). It is useful because configs sometimes required templating. Also prometheus chart should be very flexible to most use cases to be ported to official reps
* Provide flexible way to specify prometheus rules in umbrella chart resources (example you can find here #80 ). It is useful because rules sometimes required templating. Also prometheus chart should be very flexible to most use cases to be ported to official reps 
* ServiceMonitor TPR was created to provide way when external charts create it's own ServiceMonitor for their own services. From that point of view we should provide way to specify custom selectors for ServiceMonitors. (example you can find here #80 )
* Custom Rules useful to specify custom alerts. So we should support configurable rules config maps selector (example you can find here #80 )