### PR TITLE
Added prometheus default selectors for rules and service Monitors

### DIFF
--- a/incubator/prometheus/templates/prometheus.yaml
+++ b/incubator/prometheus/templates/prometheus.yaml
@@ -34,7 +34,7 @@ spec:
   serviceMonitorSelector:
     matchLabels:
 {{ toYaml .Values.serviceMonitorsSelector | indent 6 }}
-{{- else if  .Values.serviceMonitors }}
+{{- else }}
   serviceMonitorSelector:
     matchLabels:
       app: {{ template "name" . }}
@@ -44,7 +44,7 @@ spec:
   ruleSelector:
     matchLabels:
 {{ toYaml .Values.rulesSelector | indent 6 }}
-{{- else if  .Values.rules.value }}
+{{- else }}
   ruleSelector:
     matchLabels:
       app: {{ template "name" . }}


### PR DESCRIPTION
## What 
* Added default selector for Service Monitor
* Added default selector for Rules

## Why
* Default selectors useful for extend prometheus from external charts by defining Service Monitors and Rules