### PR TITLE
Revert back exporter-kube-state into kube-prometheus deps

### DIFF
--- a/incubator/kube-prometheus/requirements.yaml
+++ b/incubator/kube-prometheus/requirements.yaml
@@ -20,6 +20,9 @@ dependencies:
   - name: exporter-kube-scheduler
     version: 0.1.0
     repository: https://charts.cloudposse.com/incubator
+  - name: exporter-kube-state
+    version: 0.1.0
+    repository: https://charts.cloudposse.com/incubator
   - name: exporter-kubelets
     version: 0.1.0
     repository: https://charts.cloudposse.com/incubator


### PR DESCRIPTION
## What
* Revert back exporter-kube-state into kube-prometheus requirements

## Why
* exporter-kube-state is a part of end-to-end prometheus chart, and was removed from it's deps temporary. Now reverted back