### PR TITLE
Update nginx ingress to version 0.9.0-beta.3

### DIFF
--- a/incubator/nginx-ingress/Chart.yaml
+++ b/incubator/nginx-ingress/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Nginx Ingress
 name: nginx-ingress
-version: 0.1.4
+version: 0.1.5

--- a/incubator/nginx-ingress/templates/deployment.yaml
+++ b/incubator/nginx-ingress/templates/deployment.yaml
@@ -45,6 +45,6 @@ spec:
         args:
         - /nginx-ingress-controller
         - --default-backend-service=$(POD_NAMESPACE)/{{ template "default-backend" . }}
-        - --nginx-configmap=$(POD_NAMESPACE)/{{ template "fullname" . }}
+        - --configmap=$(POD_NAMESPACE)/{{ template "fullname" . }}
         resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/incubator/nginx-ingress/values.yaml
+++ b/incubator/nginx-ingress/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: "gcr.io/google_containers/nginx-ingress-controller"
-  tag: "0.8.3"
+  tag: "0.9.0-beta.3"
   pullPolicy: "IfNotPresent"
 
 service:


### PR DESCRIPTION
## What
* Update chart to use nginx ingress 0.9.0-beta.3

## Why
* Support multiple features like 3d party auth and annotations to config nginx