### PR TITLE
Added default resource limits on prometheus

### DIFF
--- a/incubator/kube-prometheus/values.yaml
+++ b/incubator/kube-prometheus/values.yaml
@@ -183,9 +183,12 @@ prometheus:
   ## Resource limits & requests
   ## Ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ##
-  resources: {}
-    # requests:
-    #   memory: 400Mi
+  resources:
+     requests:
+       memory: 400Mi
+     limits:
+       memory: 800Mi
+
 
   ## How long to retain metrics
   ##

--- a/incubator/prometheus/values.yaml
+++ b/incubator/prometheus/values.yaml
@@ -62,9 +62,12 @@ replicaCount: 1
 ## Resource limits & requests
 ## Ref: https://kubernetes.io/docs/user-guide/compute-resources/
 ##
-resources: {}
-  # requests:
-  #   memory: 400Mi
+resources:
+   requests:
+     memory: 400Mi
+   limits:
+     memory: 800Mi
+
 
 ## How long to retain metrics
 ##


### PR DESCRIPTION
## What
* Added default resources limits to prometheus

## Why
* If resources not specify prometheus-operator request 2G and can grow. This makes crash of some small nodes in kubernetes cluster