### PR TITLE
Deploy Github Authorized Keys on All Nodes

### DIFF
--- a/incubator/github-authorized-keys/Chart.yaml
+++ b/incubator/github-authorized-keys/Chart.yaml
@@ -4,7 +4,7 @@ description: |-
   * We recommend that you install this chart into the `kube-system` namespace.
   * There should only be one installation per cluster (other releases will fail because of name conflict)
 name: github-authorized-keys
-version: 0.2.1
+version: 0.2.2
 keywords:
 - ssh
 - github

--- a/incubator/github-authorized-keys/templates/daemonset.yaml
+++ b/incubator/github-authorized-keys/templates/daemonset.yaml
@@ -16,6 +16,9 @@ spec:
     spec:
       hostNetwork: true
       dnsPolicy: Default
+      tolerations:
+       - key: node-role.kubernetes.io/master
+         effect: NoSchedule
       containers:
       - name: github-authorized-keys
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
## what
* Add master toleration

## why
* We want `github-authorized-keys` deployed as a `DaemonSet` on *all* nodes, including master nodes
* With new versions of `kops` and `kubernetes`, by default pods are not scheduled on `master` nodes