### PR TITLE
Fix lamp bind new version vps

### DIFF
--- a/incubator/lamp/Chart.yaml
+++ b/incubator/lamp/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Linux, Apache, MySQL, PHP (aka LAMP)
 name: lamp
-version: 0.1.3
+version: 0.1.4

--- a/incubator/lamp/requirements.yaml
+++ b/incubator/lamp/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: "0.1.3"
   repository: "https://charts.cloudposse.com/incubator"
 - name: "vps"
-  version: "0.1.0"
+  version: "0.1.1"
   repository: "https://charts.cloudposse.com/incubator"
 - name: "mysql"
   version: "0.2.4"


### PR DESCRIPTION
## What
* Bump new version `vps` chart in `lamp` chart deps

## Why
* Old version does not support new helm