### PR TITLE
Feature add chart museum

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ services:
 install:
   - make init
   - sudo make helm:install
-  - helm repo add opsgoodness http://charts.opsgoodness.com
-  - helm repo add inclubator https://kubernetes-charts-incubator.storage.googleapis.com
   - make helm:repo:add-remote
   - make helm:repo:add-current
   - make docker:login

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ install:
   - make init
   - sudo make helm:install
   - helm repo add opsgoodness http://charts.opsgoodness.com
+  - helm repo add inclubator https://kubernetes-charts-incubator.storage.googleapis.com
   - make helm:repo:add-remote
   - make helm:repo:add-current
   - make docker:login

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,23 +6,11 @@ ADD ./ /charts
 
 WORKDIR /charts
 
-VOLUME ["/charts"]
-
 ENV CURRENT_REPO_URL=
 
-RUN set -ex \
-      && apk update \
-      && apk add --no-cache \
-          curl \
-          git \
-          make \
-          bash \
-      && make init \
-      && make helm:install \
-      && make helm:repo:add-remote \
-      && make helm:repo:build REPO_NAME=demo \
-      && make helm:repo:build REPO_NAME=incubator \
-      && make helm:repo:build REPO_NAME=stable ;
+## Do not pack charts inside of container until this bug would be solved
+## https://github.com/moby/moby/issues/22260
+## https://github.com/kubernetes/helm/blob/master/pkg/downloader/manager.go#L220
 
 EXPOSE 8879
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ ADD ./ /charts
 
 WORKDIR /charts
 
+VOLUME ["/charts"]
+
 ENV CURRENT_REPO_URL=
 
 RUN set -ex \

--- a/incubator/chartmuseum/.helmignore
+++ b/incubator/chartmuseum/.helmignore
@@ -19,3 +19,5 @@
 .project
 .idea/
 *.tmproj
+# OWNERS file for Kubernetes
+OWNERS

--- a/incubator/chartmuseum/.helmignore
+++ b/incubator/chartmuseum/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/incubator/chartmuseum/Chart.yaml
+++ b/incubator/chartmuseum/Chart.yaml
@@ -8,3 +8,5 @@ icon: https://raw.githubusercontent.com/chartmuseum/chartmuseum/master/logo.png
 maintainers:
 - name: ChartMuseum
   email: chartmuseum@gmail.com
+- name: Cloud Posse
+  email: hello@cloudposse.com

--- a/incubator/chartmuseum/Chart.yaml
+++ b/incubator/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Helm Chart Repository with support for Amazon S3 and Google Cloud Storage
 name: chartmuseum
-version: 0.1.4
+version: 0.2.0
 appVersion: 0.2.7
 home: https://github.com/chartmuseum/chartmuseum
 icon: https://raw.githubusercontent.com/chartmuseum/chartmuseum/master/logo.png

--- a/incubator/chartmuseum/Chart.yaml
+++ b/incubator/chartmuseum/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Helm Chart Repository with support for Amazon S3 and Google Cloud Storage
 name: chartmuseum
-version: 0.1.2
-appVersion: 0.2.6
+version: 0.1.4
+appVersion: 0.2.7
 home: https://github.com/chartmuseum/chartmuseum
 icon: https://raw.githubusercontent.com/chartmuseum/chartmuseum/master/logo.png
 maintainers:

--- a/incubator/chartmuseum/Chart.yaml
+++ b/incubator/chartmuseum/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+description: Helm Chart Repository with support for Amazon S3 and Google Cloud Storage
+name: chartmuseum
+version: 0.1.2
+appVersion: 0.2.6
+home: https://github.com/chartmuseum/chartmuseum
+icon: https://raw.githubusercontent.com/chartmuseum/chartmuseum/master/logo.png
+maintainers:
+- name: ChartMuseum
+  email: chartmuseum@gmail.com

--- a/incubator/chartmuseum/OWNERS
+++ b/incubator/chartmuseum/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- jdolitsky
+reviewers:
+- jdolitsky

--- a/incubator/chartmuseum/README.md
+++ b/incubator/chartmuseum/README.md
@@ -1,0 +1,5 @@
+# ChartMuseum Helm Chart
+
+Work in progress...
+
+Please see https://github.com/chartmuseum/chartmuseum

--- a/incubator/chartmuseum/requirements.yaml
+++ b/incubator/chartmuseum/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- name: common
+  version: 0.0.1
+  repository: https://kubernetes-charts-incubator.storage.googleapis.com/

--- a/incubator/chartmuseum/templates/NOTES.txt
+++ b/incubator/chartmuseum/templates/NOTES.txt
@@ -1,0 +1,3 @@
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named {{ .Release.Name }}.

--- a/incubator/chartmuseum/templates/deployment.yaml
+++ b/incubator/chartmuseum/templates/deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {{ include "common.fullname" . }}
+  annotations:
+{{ toYaml .Values.deployment.annotations | indent 4 }}
   labels:
 {{ include "common.labels.standard" . | indent 4 }}
 spec:
@@ -9,6 +11,8 @@ spec:
   template:
     metadata:
       name: {{ include "common.fullname" . }}
+      annotations:
+{{ toYaml .Values.replica.annotations | indent 8 }}
       labels:
         app: {{ template "common.name" . }}
         release: {{ .Release.Name | quote }}
@@ -24,18 +28,19 @@ spec:
           value: {{ $value | quote }}
 {{- end }}
 {{- end }}
+{{- $secret_name := include "common.fullname" . }}
 {{- range $name, $value := .Values.env.secret }}
-{{- if not (empty $value) }}
+{{- if not ( empty $value) }}
         - name: {{ $name | quote }}
           valueFrom:
             secretKeyRef:
-              name: {{ include "common.fullname" . }}
+              name: {{ $secret_name }}
               key: {{ $name | quote }}
 {{- end }}
 {{- end }}
         args:
         - --port={{ .Values.service.internalPort }}
-{{- if .Values.env.open.STORAGE == "local" }}
+{{- if eq .Values.env.open.STORAGE "local" }}
         - --storage-local-rootdir=/storage
 {{- end }}
         ports:
@@ -43,14 +48,14 @@ spec:
         livenessProbe:
           tcpSocket:
             port: {{ .Values.service.internalPort }}
-            initialDelaySeconds: 5
-            periodSeconds: 10
+          initialDelaySeconds: 5
+          periodSeconds: 10
         readinessProbe:
           tcpSocket:
             port: {{ .Values.service.internalPort }}
-            initialDelaySeconds: 5
-            periodSeconds: 10
-{{- if and ( .Values.env.open.STORAGE == "local") }}
+          initialDelaySeconds: 5
+          periodSeconds: 10
+{{- if eq .Values.env.open.STORAGE "local" }}
         volumeMounts:
         - mountPath: /storage
           name: storage-volume
@@ -58,9 +63,6 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
       volumes:
-{{- if .Values.persistence.volumes }}
-{{ toYaml .Values.persistence.volumes | indent 6 }}
-{{- end }}
       - name: storage-volume
       {{- if .Values.persistence.Enabled }}
         persistentVolumeClaim:

--- a/incubator/chartmuseum/templates/deployment.yaml
+++ b/incubator/chartmuseum/templates/deployment.yaml
@@ -8,6 +8,11 @@ metadata:
 {{ include "common.labels.standard" . | indent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+  revisionHistoryLimit: 10
   template:
     metadata:
       name: {{ include "common.fullname" . }}
@@ -46,12 +51,14 @@ spec:
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:
-          tcpSocket:
+          httpGet:
+            path: /health
             port: {{ .Values.service.internalPort }}
           initialDelaySeconds: 5
           periodSeconds: 10
         readinessProbe:
-          tcpSocket:
+          httpGet:
+            path: /health
             port: {{ .Values.service.internalPort }}
           initialDelaySeconds: 5
           periodSeconds: 10

--- a/incubator/chartmuseum/templates/deployment.yaml
+++ b/incubator/chartmuseum/templates/deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ include "common.fullname" . }}
+  labels:
+{{ include "common.labels.standard" . | indent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      name: {{ include "common.fullname" . }}
+      labels:
+        app: {{ template "common.name" . }}
+        release: {{ .Release.Name | quote }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+{{- range $name, $value := .Values.env.open }}
+{{- if not (empty $value) }}
+        - name: {{ $name | quote }}
+          value: {{ $value | quote }}
+{{- end }}
+{{- end }}
+{{- range $name, $value := .Values.env.secret }}
+{{- if not (empty $value) }}
+        - name: {{ $name | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "common.fullname" . }}
+              key: {{ $name | quote }}
+{{- end }}
+{{- end }}
+        args:
+        - --port={{ .Values.service.internalPort }}
+{{- if .Values.env.open.STORAGE == "local" }}
+        - --storage-local-rootdir=/storage
+{{- end }}
+        ports:
+        - containerPort: {{ .Values.service.internalPort }}
+        livenessProbe:
+          tcpSocket:
+            port: {{ .Values.service.internalPort }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+        readinessProbe:
+          tcpSocket:
+            port: {{ .Values.service.internalPort }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+{{- if and ( .Values.env.open.STORAGE == "local") }}
+        volumeMounts:
+        - mountPath: /storage
+          name: storage-volume
+{{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+      volumes:
+{{- if .Values.persistence.volumes }}
+{{ toYaml .Values.persistence.volumes | indent 6 }}
+{{- end }}
+      - name: storage-volume
+      {{- if .Values.persistence.Enabled }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.persistence.ExistingClaim | default (include "common.fullname" .) }}
+      {{- else }}
+        emptyDir: {}
+      {{- end -}}

--- a/incubator/chartmuseum/templates/ingress.yaml
+++ b/incubator/chartmuseum/templates/ingress.yaml
@@ -1,17 +1,23 @@
-{{- if .Values.ingress.enabled -}}
+{{- $root := . -}}
 {{- $servicePort := .Values.service.externalPort -}}
 {{- $serviceName := include "common.labels.standard" . -}}
+{{- range .Values.ingress }}
+---
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   annotations:
-{{ toYaml .Values.ingress.annotations | indent 4 }}
+{{ toYaml .annotations | indent 4 }}
   labels:
-{{ include "common.labels.standard" . | indent 4 }}
-  name: {{ include "common.fullname" . }}
+{{- if .labels }}
+{{ toYaml .labels | indent 4 }}
+{{- end }}
+{{ include "common.labels.standard" $root | indent 4 }}
+    ingressName: {{ .name }}
+  name: {{ include "common.fullname" $root }}-{{ .name }}
 spec:
   rules:
-  {{- range $host, $path := .Values.ingress.hosts }}
+  {{- range $host, $path := .hosts }}
     - host: {{ $host }}
       http:
         paths:
@@ -20,8 +26,8 @@ spec:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
   {{- end -}}
-  {{- if .Values.ingress.tls }}
+  {{- if .tls }}
   tls:
-{{ toYaml .Values.ingress.tls | indent 4 }}
+{{ toYaml .tls | indent 4 }}
   {{- end -}}
 {{- end -}}

--- a/incubator/chartmuseum/templates/ingress.yaml
+++ b/incubator/chartmuseum/templates/ingress.yaml
@@ -1,33 +1,33 @@
-{{- $root := . -}}
 {{- $servicePort := .Values.service.externalPort -}}
-{{- $serviceName := include "common.labels.standard" . -}}
-{{- range .Values.ingress }}
+{{- $serviceName := include "common.fullname" . -}}
+{{- if .Values.ingress.enabled }}
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
+  name: {{ include "common.fullname" . }}
   annotations:
-{{ toYaml .annotations | indent 4 }}
+{{ toYaml .Values.ingress.annotations | indent 4 }}
   labels:
-{{- if .labels }}
-{{ toYaml .labels | indent 4 }}
+{{- if .Values.ingress.labels }}
+{{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
-{{ include "common.labels.standard" $root | indent 4 }}
-    ingressName: {{ .name }}
-  name: {{ include "common.fullname" $root }}-{{ .name }}
+{{ include "common.labels.standard" . | indent 4 }}
 spec:
   rules:
-  {{- range $host, $path := .hosts }}
-    - host: {{ $host }}
-      http:
-        paths:
-          - path: {{ $path }}
-            backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
+  {{- range $host, $paths := .Values.ingress.hosts }}
+  - host: {{ $host }}
+    http:
+      paths:
+      {{- range $paths }}
+      - path: {{ . }}
+        backend:
+          serviceName: {{ $serviceName }}
+          servicePort: {{ $servicePort }}
+      {{- end -}}
   {{- end -}}
-  {{- if .tls }}
+  {{- if .Values.ingress.tls }}
   tls:
-{{ toYaml .tls | indent 4 }}
+{{ toYaml .Values.ingress.tls | indent 4 }}
   {{- end -}}
 {{- end -}}

--- a/incubator/chartmuseum/templates/ingress.yaml
+++ b/incubator/chartmuseum/templates/ingress.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.ingress.enabled -}}
+{{- $servicePort := .Values.service.externalPort -}}
+{{- $serviceName := include "common.labels.standard" . -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+{{ toYaml .Values.ingress.annotations | indent 4 }}
+  labels:
+{{ include "common.labels.standard" . | indent 4 }}
+  name: {{ include "common.fullname" . }}
+spec:
+  rules:
+  {{- range $host, $path := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: {{ $path }}
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+  {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/incubator/chartmuseum/templates/pvc.yaml
+++ b/incubator/chartmuseum/templates/pvc.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.persistence.Enabled (not .Values.persistence.ExistingClaim) -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "common.fullname" . }}
+  labels:
+    app: {{ include "common.fullname" . }}
+    release: {{ .Release.Name | quote }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.AccessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.Size | quote }}
+{{- if .Values.persistence.StorageClass }}
+{{- if (eq "-" .Values.persistence.StorageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.StorageClass }}"
+{{- end }}
+{{- end }}
+{{- end }}

--- a/incubator/chartmuseum/templates/secret.yaml
+++ b/incubator/chartmuseum/templates/secret.yaml
@@ -8,6 +8,6 @@ type: Opaque
 data:
 {{- range $name, $value := .Values.env.secret }}
 {{- if not (empty $value) }}
-  {{ $name }}: {{ $value | quote }}
+  {{ $name }}: {{ $value | b64enc }}
 {{- end }}
 {{- end }}

--- a/incubator/chartmuseum/templates/secret.yaml
+++ b/incubator/chartmuseum/templates/secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "common.fullname" . }}
+  labels:
+{{ include "common.labels.standard" . | indent 4 }}
+type: Opaque
+data:
+{{- range $name, $value := .Values.env.secret }}
+{{- if not (empty $value) }}
+  {{ $name }}: {{ $value | quote }}
+{{- end }}
+{{- end }}

--- a/incubator/chartmuseum/templates/service.yaml
+++ b/incubator/chartmuseum/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "common.fullname" . }}
+  labels:
+{{ include "common.labels.standard" . | indent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.externalPort }}
+    targetPort: {{ .Values.service.internalPort }}
+    protocol: TCP
+    name: {{ .Release.Name }}
+  selector:
+    app: {{ template "common.name" . }}
+    release: {{ .Release.Name | quote }}

--- a/incubator/chartmuseum/templates/service.yaml
+++ b/incubator/chartmuseum/templates/service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "common.fullname" . }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
   labels:
 {{ include "common.labels.standard" . | indent 4 }}
 spec:

--- a/incubator/chartmuseum/templates/service.yaml
+++ b/incubator/chartmuseum/templates/service.yaml
@@ -6,6 +6,10 @@ metadata:
 {{ toYaml .Values.service.annotations | indent 4 }}
   labels:
 {{ include "common.labels.standard" . | indent 4 }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/incubator/chartmuseum/values.yaml
+++ b/incubator/chartmuseum/values.yaml
@@ -40,10 +40,15 @@ env:
     BASIC_AUTH_USER:
     # password for basic http authentication
     BASIC_AUTH_PASS:
-    # tls certificate chain file content
-    TLS_CERT:
-    # tls key file content
-    TLS_KEY:
+deployment:
+  ## Chartmuseum Deployment annotations
+  annotations:
+  #   name: value
+replica:
+  ## Chartmuseum Replicas annotations
+  annotations:
+  ## Read more about kube2iam to provide access to s3 https://github.com/jtblin/kube2iam
+  #   iam.amazonaws.com/role: role-arn
 service:
   type: ClusterIP
   externalPort: 8080
@@ -64,7 +69,7 @@ persistence:
   ## If defined, PVC must be created manually before volume will be bound
   # ExistingClaim:
 
-  ## jenkins data Persistent Volume Storage Class
+  ## Chartmuseum data Persistent Volume Storage Class
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning
   ## If undefined (the default) or set to null, no storageClassName spec is
@@ -72,3 +77,27 @@ persistence:
   ##   GKE, AWS & OpenStack)
   ##
   # StorageClass: "-"
+ingress:
+  ## If true, Chartmuseum Ingress will be created
+  ##
+  enabled: false
+
+  ## Chartmuseum Ingress annotations
+  ##
+  # annotations:
+  #   kubernetes.io/ingress.class: nginx
+  #   kubernetes.io/tls-acme: 'true'
+
+  ## Chartmuseum Ingress hostnames
+  ## Must be provided if Ingress is enabled
+  ##
+  # hosts:
+  #   "chartmuseum.domain.com": /
+
+  ## Chartmuseum Ingress TLS configuration
+  ## Secrets must be manually created in the namespace
+  ##
+  # tls:
+  #   - secretName: chartmuseum-server-tls
+  #     hosts:
+  #       - chartmuseum.domain.com

--- a/incubator/chartmuseum/values.yaml
+++ b/incubator/chartmuseum/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 image:
   repository: chartmuseum/chartmuseum
-  tag: v0.2.6
+  tag: v0.2.7
   pullPolicy: IfNotPresent
 env:
   open:
@@ -53,6 +53,8 @@ service:
   type: ClusterIP
   externalPort: 8080
   internalPort: 8080
+  annotations: {}
+    # foo.io/bar: "true"
 resources:
   limits:
     cpu: 100m
@@ -77,27 +79,32 @@ persistence:
   ##   GKE, AWS & OpenStack)
   ##
   # StorageClass: "-"
-ingress:
-  ## If true, Chartmuseum Ingress will be created
-  ##
-  enabled: false
 
-  ## Chartmuseum Ingress annotations
-  ##
-  # annotations:
-  #   kubernetes.io/ingress.class: nginx
-  #   kubernetes.io/tls-acme: 'true'
+## Ingress for load balancer
+# ingress:
+# - name: "default"
+## Chartmuseum Ingress labels
+##
+#   labels:
+#     dns: "route53"
 
-  ## Chartmuseum Ingress hostnames
-  ## Must be provided if Ingress is enabled
-  ##
-  # hosts:
-  #   "chartmuseum.domain.com": /
+## Chartmuseum Ingress annotations
+##
+#   annotations:
+#     kubernetes.io/ingress.class: nginx
+#     kubernetes.io/tls-acme: "true"
 
-  ## Chartmuseum Ingress TLS configuration
-  ## Secrets must be manually created in the namespace
-  ##
-  # tls:
-  #   - secretName: chartmuseum-server-tls
-  #     hosts:
-  #       - chartmuseum.domain.com
+## Chartmuseum Ingress hostnames
+## Must be provided if Ingress is enabled
+##
+#   hosts:
+#     "chartmuseum.domain.com": /
+#     "www.chartmuseum.domain.com": /
+
+## Chartmuseum Ingress TLS configuration
+## Secrets must be manually created in the namespace
+##
+#   tls:
+#   - secretName: chartmuseum-server-tls
+#     hosts:
+#     - chartmuseum.domain.com

--- a/incubator/chartmuseum/values.yaml
+++ b/incubator/chartmuseum/values.yaml
@@ -1,0 +1,74 @@
+replicaCount: 1
+image:
+  repository: chartmuseum/chartmuseum
+  tag: v0.2.6
+  pullPolicy: IfNotPresent
+env:
+  open:
+    # storage backend, can be one of: local, amazon, google
+    STORAGE: local
+    # s3 bucket to store charts for amazon storage backend
+    STORAGE_AMAZON_BUCKET:
+    # prefix to store charts for amazon storage backend
+    STORAGE_AMAZON_PREFIX:
+    # region of s3 bucket to store charts
+    STORAGE_AMAZON_REGION:
+    # alternative s3 endpoint
+    STORAGE_AMAZON_ENDPOINT:
+    # gcs bucket to store charts for google storage backend
+    STORAGE_GOOGLE_BUCKET:
+    # prefix to store charts for google storage backend
+    STORAGE_GOOGLE_PREFIX:
+    # form field which will be queried for the chart file content
+    CHART_POST_FORM_FIELD_NAME: chart
+    # form field which will be queried for the provenance file content
+    PROV_POST_FORM_FIELD_NAME: prov
+    # show debug messages
+    DEBUG: false
+    # output structured logs as json
+    LOG_JSON: true
+    # disable Prometheus metrics
+    DISABLE_METRICS: true
+    # disable all routes prefixed with /api
+    DISABLE_API: true
+    # allow chart versions to be re-uploaded
+    ALLOW_OVERWRITE: false
+    # absolute url for .tgzs in index.yaml
+    CHART_URL: http://localhost
+  secret:
+    # username for basic http authentication
+    BASIC_AUTH_USER:
+    # password for basic http authentication
+    BASIC_AUTH_PASS:
+    # tls certificate chain file content
+    TLS_CERT:
+    # tls key file content
+    TLS_KEY:
+service:
+  type: ClusterIP
+  externalPort: 8080
+  internalPort: 8080
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 80m
+    memory: 64Mi
+persistence:
+  Enabled: false
+  AccessMode: ReadWriteOnce
+  Size: 8Gi
+  ## A manually managed Persistent Volume and Claim
+  ## Requires Persistence.Enabled: true
+  ## If defined, PVC must be created manually before volume will be bound
+  # ExistingClaim:
+
+  ## jenkins data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # StorageClass: "-"

--- a/incubator/chartmuseum/values.yaml
+++ b/incubator/chartmuseum/values.yaml
@@ -42,11 +42,11 @@ env:
     BASIC_AUTH_PASS:
 deployment:
   ## Chartmuseum Deployment annotations
-  annotations:
+  annotations: {}
   #   name: value
 replica:
   ## Chartmuseum Replicas annotations
-  annotations:
+  annotations: {}
   ## Read more about kube2iam to provide access to s3 https://github.com/jtblin/kube2iam
   #   iam.amazonaws.com/role: role-arn
 service:
@@ -81,8 +81,8 @@ persistence:
   # StorageClass: "-"
 
 ## Ingress for load balancer
-# ingress:
-# - name: "default"
+ingress:
+  enabled: false
 ## Chartmuseum Ingress labels
 ##
 #   labels:
@@ -98,8 +98,9 @@ persistence:
 ## Must be provided if Ingress is enabled
 ##
 #   hosts:
-#     "chartmuseum.domain.com": /
-#     "www.chartmuseum.domain.com": /
+#     chartmuseum.domain.com:
+#         - /charts
+#         - /index.yaml
 
 ## Chartmuseum Ingress TLS configuration
 ## Secrets must be manually created in the namespace

--- a/incubator/chartmuseum/values.yaml
+++ b/incubator/chartmuseum/values.yaml
@@ -34,7 +34,7 @@ env:
     # allow chart versions to be re-uploaded
     ALLOW_OVERWRITE: false
     # absolute url for .tgzs in index.yaml
-    CHART_URL: http://localhost
+    CHART_URL:
   secret:
     # username for basic http authentication
     BASIC_AUTH_USER:

--- a/incubator/kube-lego/values.yaml
+++ b/incubator/kube-lego/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 debug: false
 image:
   repository: jetstack/kube-lego
-  tag: 0.1.3
+  tag: 0.1.5
   pullPolicy: IfNotPresent
 lego:
   email: ""

--- a/incubator/kube2iam-kops/Chart.yaml
+++ b/incubator/kube2iam-kops/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: kube2iam-kops
-version: 0.1.0
+version: 0.1.1

--- a/incubator/kube2iam-kops/requirements.yaml
+++ b/incubator/kube2iam-kops/requirements.yaml
@@ -1,5 +1,5 @@
 # requirements.yaml
 dependencies:
 - name: "kube2iam"
-  version: "0.2.1"
+  version: "0.5.0"
   repository: "https://kubernetes-charts.storage.googleapis.com"

--- a/incubator/kube2iam-kops/values.yaml
+++ b/incubator/kube2iam-kops/values.yaml
@@ -7,11 +7,13 @@ define:
   - &IAM_DEFAULT_ROLE ""   # Default role
 
 kube2iam:
+  verbose: false
+
   extraArgs:
     base-role-arn: *IAM_BASE_ROLE_ARN
     default-role: *IAM_DEFAULT_ROLE
-  #   api-server: ...
-  #   api-token: ...
+    #   api-server: ...
+    #   api-token: ...
 
   host:
     ip: $(HOST_IP)
@@ -20,8 +22,14 @@ kube2iam:
 
   image:
     repository: jtblin/kube2iam
-    tag: 0.4.0
+    tag: 0.7.0
     pullPolicy: IfNotPresent
+
+  # AWS Access keys to inject as environment variables
+  aws:
+    secret_key: ""
+    access_key: ""
+    region: ""
 
   ## Node labels for pod assignment
   ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
@@ -32,6 +40,17 @@ kube2iam:
   ##
   podAnnotations: {}
 
+  podLabels: {}
+
+  rbac:
+    ## If true, create & use RBAC resources
+    ##
+    create: false
+
+    ## Ignored if rbac.create is true
+    ##
+    serviceAccountName: default
+
   resources:
     limits:
       cpu: 4m
@@ -40,4 +59,11 @@ kube2iam:
       cpu: 4m
       memory: 16Mi
 
+  ## Strategy for DaemonSet updates (requires Kubernetes 1.6+)
+  ## Ref: https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/
+  ##
+  updateStrategy: OnDelete
+
   verbose: false
+
+  tolerations: []

--- a/incubator/nginx-ingress/requirements.yaml
+++ b/incubator/nginx-ingress/requirements.yaml
@@ -1,5 +1,5 @@
 # requirements.yaml
 dependencies:
 - name: "nginx-default-backend"
-  version: "0.2.1"
+  version: "0.2.2"
   repository: "https://charts.cloudposse.com/incubator"

--- a/incubator/thumbor/requirements.yaml
+++ b/incubator/thumbor/requirements.yaml
@@ -1,5 +1,5 @@
 # requirements.yaml
 dependencies:
 - name: "remotecv"
-  version: "0.1.0"
+  version: "0.1.1"
   repository: "https://charts.cloudposse.com/incubator"


### PR DESCRIPTION
## What
* Chartmuseum chart
* Redo how we build helm serve docker image
* Bump versions for thumbor and nginx-ingress

## Why
* To build private chart repo
* Because of bug in new docker helm failed https://github.com/moby/moby/issues/22260
   https://github.com/kubernetes/helm/blob/master/pkg/downloader/manager.go#L220
* Need to use new versions of charts with new helm

## Features
* Allow to upload charts
* Allow to serve charts
* Auto index based on files in directory
* Use aws s3 as storage
* Support ingress
* Support ingress annotations
* Support kube2iam annotations
* Support base http auth