### PR TITLE
Feature route53 support kube2iam

### DIFF
--- a/incubator/route53-kubernetes/Chart.yaml
+++ b/incubator/route53-kubernetes/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Map k8s services to route53 domains
 name: route53-kubernetes
-version: 0.1.1
+version: 0.1.2

--- a/incubator/route53-kubernetes/templates/daemonset.yaml
+++ b/incubator/route53-kubernetes/templates/daemonset.yaml
@@ -12,6 +12,9 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/role: master
+      tolerations:
+        - key: node-role.kubernetes.io/master
+         effect: NoSchedule
       hostNetwork: true
       dnsPolicy: Default
       containers:

--- a/incubator/route53-kubernetes/templates/daemonset.yaml
+++ b/incubator/route53-kubernetes/templates/daemonset.yaml
@@ -13,8 +13,8 @@ spec:
       nodeSelector:
         kubernetes.io/role: master
       tolerations:
-        - key: node-role.kubernetes.io/master
-         effect: NoSchedule
+      - key: "node-role.kubernetes.io/master"
+        effect: "NoSchedule"
       hostNetwork: true
       dnsPolicy: Default
       containers:


### PR DESCRIPTION
## What
* Added tolerate 

## Why
* Allow to run pod on master