### PR TITLE
Depricate chart-repo

### DIFF
--- a/incubator/chart-repo/README.md
+++ b/incubator/chart-repo/README.md
@@ -1,1 +1,3 @@
 # Helm repo chart
+
+**Depricated: Use Geodesic [Master Helmfile](https://github.com/cloudposse/geodesic/blob/master/rootfs/conf/kops/helmfile.yaml) with [Helmfile](https://github.com/roboll/helmfile) instead** 


### PR DESCRIPTION
## What
* Depricate `incubator/chart-repo`

## Why
* Reduce count of custom charts