### PR TITLE
Support portal hostname formats

### DIFF
--- a/incubator/portal/templates/_helpers.tpl
+++ b/incubator/portal/templates/_helpers.tpl
@@ -30,7 +30,7 @@ Create a default fully qualified oauth2-proxy name.
 {/*
 Schema
 */}}
-{{- define "portal.schema" -}}
+{{- define "portal.scheme" -}}
 {{- if .Values.ingress.tls.enabled -}}
 {{- printf "https" -}}
 {{- else -}}
@@ -43,21 +43,21 @@ Schema
 External auth auth-url endpoint
 */}}
 {{- define "portal.auth-url" -}}
-{{- printf "%s://$host/oauth2/auth" (include "portal.schema" . ) -}}
+{{- printf "%s://$host/oauth2/auth" (include "portal.scheme" . ) -}}
 {{- end -}}
 
 {/*
 External auth auth-signin endpoint
 */}}
 {{- define "portal.auth-signin" -}}
-{{- printf "%s://$host/oauth2/start" (include "portal.schema" . ) -}}
+{{- printf "%s://$host/oauth2/start" (include "portal.scheme" . ) -}}
 {{- end -}}
 
 {/*
 External auth auth-request-redirect endpoint
 */}}
 {{- define "portal.auth-request-redirect" -}}
-{{- printf "%s://$host/" (include "portal.schema" . ) -}}
+{{- printf "%s://$host/" (include "portal.scheme" . ) -}}
 {{- end -}}
 
 {{- /*

--- a/incubator/portal/templates/dashboard.configmap.yaml
+++ b/incubator/portal/templates/dashboard.configmap.yaml
@@ -1,5 +1,6 @@
 {{- $basehost := .Values.config.basehost -}}
-{{- $schema := ( include "portal.schema" . ) -}}
+{{- $hostnameFormat := .Values.config.hostnameFormat -}}
+{{- $scheme := ( include "portal.scheme" . ) -}}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -42,7 +43,7 @@ data:
   {{ $url := $value.endpoint }}
                 <a class="nav-link" id="{{ $name }}-link" href="{{ $url }}" data-toggle="collapse" data-target="#{{ $name }}" aria-expanded="false" aria-controls="{{ $name }}">{{ $value.name }}</a>
 {{ else }}
-  {{ $url := ( printf "%s://%s.%s" $schema $name $basehost ) }}
+  {{ $url := ( printf ("%s://" + $hostnameFormat) $scheme $name $basehost ) }}
                 <a class="nav-link" id="{{ $name }}-link" href="{{ $url }}" data-toggle="collapse" data-target="#{{ $name }}" aria-expanded="false" aria-controls="{{ $name }}">{{ $value.name }}</a>
 {{ end }}
               </li>
@@ -57,7 +58,7 @@ data:
   {{ $url := $value.endpoint }}
           <iframe class="embed-responsive-item collapse" aria-labelledby="{{ $name }}-link" data-parent="#accordion" id="{{ $name }}" data-src="{{ $url }}" allowfullscreen></iframe>
 {{ else }}
-  {{ $url := ( printf "%s://%s.%s" $schema $name $basehost ) }}
+  {{ $url := ( printf "%s://%s.%s" $scheme $name $basehost ) }}
           <iframe class="embed-responsive-item collapse" aria-labelledby="{{ $name }}-link" data-parent="#accordion" id="{{ $name }}" data-src="{{ $url }}" allowfullscreen></iframe>
 {{ end }}
 {{ end }}

--- a/incubator/portal/templates/dashboard.ingress.yaml
+++ b/incubator/portal/templates/dashboard.ingress.yaml
@@ -9,12 +9,12 @@ metadata:
   name: {{ include "common.fullname" $root }}
   annotations:
     kubernetes.io/tls-acme: {{ $root.Values.ingress.tls.enabled | quote }}
-    ingress.kubernetes.io/auth-signin: {{ template "portal.auth-signin" . }}
-    ingress.kubernetes.io/auth-url: {{ template "portal.auth-url" . }}
+    # https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md#external-authentication
     nginx.ingress.kubernetes.io/auth-signin: {{ template "portal.auth-signin" . }}
     nginx.ingress.kubernetes.io/auth-url: {{ template "portal.auth-url" . }}
 
 {{- if $root.Values.ingress.dns.enabled }}
+    # route53-kubernetes annotation
     domainName: {{ $root.Values.config.basehost | quote }}
 {{- end }}
 
@@ -27,6 +27,7 @@ metadata:
 {{ include "common.labels.standard" $root | indent 4 }}
 
 {{- if $root.Values.ingress.dns.enabled }}
+    # route53-kubernetes label
     dns: "route53"
 {{- end }}
 

--- a/incubator/portal/templates/proxy.configmap.yaml
+++ b/incubator/portal/templates/proxy.configmap.yaml
@@ -45,6 +45,6 @@ data:
 
         [frontends.{{ $name }}.routes]
           [frontends.{{ $name }}.routes.route0]
-            rule = {{ printf "Host: %s.%s" $name $basehost | quote }}
+            rule = {{ printf ("Host: " + .Values.config.hostnameFormat) $name $basehost | quote }}
 {{ end }}
 {{ end }}

--- a/incubator/portal/templates/proxy.ingress.yaml
+++ b/incubator/portal/templates/proxy.ingress.yaml
@@ -5,6 +5,7 @@
 {{- $serviceName := include "portal.proxy.fullname" . -}}
 
 {{- $basehost := .Values.config.basehost -}}
+{{- $hostnameFormat := .Values.config.hostnameFormat -}}
 
 {{ range $name, $value := .Values.backends }}
 {{ if not $value.external }}
@@ -15,15 +16,12 @@ metadata:
   name: {{ include "portal.proxy.fullname" $root }}-{{ $name }}
   annotations:
     kubernetes.io/tls-acme: {{ $root.Values.ingress.tls.enabled | quote }}
-    ingress.kubernetes.io/auth-signin: {{ template "portal.auth-signin" $root }}
-    ingress.kubernetes.io/auth-url: {{ template "portal.auth-url" $root }}
-    ingress.kubernetes.io/auth-request-redirect: {{ template "portal.auth-request-redirect" $root }}
     nginx.ingress.kubernetes.io/auth-signin: {{ template "portal.auth-signin" $root }}
     nginx.ingress.kubernetes.io/auth-url: {{ template "portal.auth-url" $root }}
     nginx.ingress.kubernetes.io/auth-request-redirect: {{ template "portal.auth-request-redirect" $root }}
 
 {{- if $root.Values.ingress.dns.enabled }}
-    domainName: {{ printf "%s.%s" $name $basehost  | quote }}
+    domainName: {{ printf $hostnameFormat $name $basehost  | quote }}
 {{- end }}
 
 {{- if $root.Values.ingress.annotations }}
@@ -44,7 +42,7 @@ metadata:
 
 spec:
   rules:
-  - host: {{ printf "%s.%s" $name $basehost  | quote }}
+  - host: {{ printf $hostnameFormat $name $basehost  | quote }}
     http:
       paths:
       - path: /
@@ -56,7 +54,7 @@ spec:
   tls:
   - secretName: {{ $serviceName }}-{{ $name }}-tls
     hosts:
-    - {{ printf "%s.%s" $name $basehost  | quote }}
+    - {{ printf $hostnameFormat $name $basehost  | quote }}
 {{- end -}}
 
 {{- end -}}

--- a/incubator/portal/templates/proxy.oauth.ingress.yaml
+++ b/incubator/portal/templates/proxy.oauth.ingress.yaml
@@ -3,6 +3,7 @@
 {{- $root := . -}}
 {{- $serviceName := include "portal.proxy.fullname" . -}}
 {{- $basehost := .Values.config.basehost -}}
+{{- $hostnameFormat := .Values.config.hostnameFormat -}}
 
 {{ range $name, $value := .Values.backends }}
 {{ if not $value.external }}
@@ -13,7 +14,7 @@ metadata:
   name: {{ include "portal.proxy.fullname" $root }}-{{ $name }}-oauth
 spec:
   rules:
-  - host: {{ printf "%s.%s" $name $basehost  | quote }}
+  - host: {{ printf $hostnameFormat $name $basehost  | quote }}
     http:
       paths:
       - path: /oauth2
@@ -25,7 +26,7 @@ spec:
   tls:
   - secretName: {{ $serviceName }}-{{ $name }}-tls
     hosts:
-    - {{ printf "%s.%s" $name $basehost  | quote }}
+    - {{ printf $hostnameFormat $name $basehost  | quote }}
 {{- end -}}
 
 {{- end -}}

--- a/incubator/portal/values.yaml
+++ b/incubator/portal/values.yaml
@@ -14,6 +14,7 @@ config:
     url: https://raw.githubusercontent.com/cloudposse/helm-chart-scaffolding/master/logo.png
     width: 45
   basehost:
+  hostnameFormat: "%s.%s"
 
 dashboard:
   replicaCount: 1
@@ -173,7 +174,6 @@ ingress:
     enabled: false
   annotations:
     kubernetes.io/ingress.class: nginx
-
 
 ## Do not change. This is exported from subcharts values
 oauth2: {}


### PR DESCRIPTION
## what
* Support a configurable format for hostnames
* Fix typo `schema` -> `scheme`

## why
* Customer expressed they want to use format like `dashboard-portal.us-west-2.staging.example.net` format, vs `dashboard.portal.us-west-2.staging.example.net` due to use of wildcard ACM certificates instead of `kube-lego` annotations

## references
- https://github.com/cloudposse/charts/issues/146