### PR TITLE
Added config to pass x auth headers

### DIFF
--- a/incubator/oauth2-proxy/Chart.yaml
+++ b/incubator/oauth2-proxy/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: oauth2-proxy
-version: 0.1.3
+version: 0.1.4

--- a/incubator/oauth2-proxy/templates/configmap.yaml
+++ b/incubator/oauth2-proxy/templates/configmap.yaml
@@ -43,6 +43,8 @@ data:
       ## when disabled the upstream Host is used as the Host Header
       pass_host_header = {{ .Values.app.passHostHeader }}
 
+      set_xauthrequest = {{ .Values.app.setXAuthRequest }}
+
       ## Email Domains to allow authentication for (this authorizes any email on this domain)
       ## for more granular authorization use `authenticated_emails_file`
       ## To authorize any email addresses use "*"

--- a/incubator/oauth2-proxy/values.yaml
+++ b/incubator/oauth2-proxy/values.yaml
@@ -51,6 +51,7 @@ app:
   passAccessToken: false
   passBasicAuth: true
   passHostHeader: true
+  setXAuthRequest: true
   customTemplatesDir:
   proxyPrefix:
   skipAuthRegex:


### PR DESCRIPTION
## What
* Make oauth2 proxy pass to upstream headers `X-Auth-Request-User` and `X-Auth-Request-Email`

## Why
* To make auto creation users on upstream backends