### PR TITLE
[incubator/thumbor] allow overriding ingress path

### DIFF
--- a/incubator/thumbor/Chart.yaml
+++ b/incubator/thumbor/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Thumbor+RemoteCV thumbnailing service
 name: thumbor
-version: 0.1.0
+version: 0.2.0

--- a/incubator/thumbor/templates/ingress.yaml
+++ b/incubator/thumbor/templates/ingress.yaml
@@ -31,7 +31,7 @@ spec:
     - host: {{ . }}
       http:
         paths:
-          - path: /
+          - path: {{ default "/" .path }}
             backend:
               serviceName: {{ template "fullname" $root }}
               servicePort: {{ $root.Values.service.externalPort }}

--- a/incubator/thumbor/values.yaml
+++ b/incubator/thumbor/values.yaml
@@ -34,7 +34,7 @@ annotations:
 #   hosts:
 #     - "thumbor.example.com"
 #     - "example.com"
-#
+#   path: /
 #
 #
 


### PR DESCRIPTION
## what
* This change allows overriding the path mapped to the thumbor service in the charts values.
* For backwards compatibility I'm rendering the path in the template with `default` to ensure that old deploys that already configure ingress wont break on the update.

## why
It makes it possible to host thumbor on the same domain as a single page application that expects thumbor to be at `/thumbor` instead of being on it's own domain.

