### PR TITLE
[incubator/thumbor] fix ingress path setting

### DIFF
--- a/incubator/thumbor/Chart.yaml
+++ b/incubator/thumbor/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Thumbor+RemoteCV thumbnailing service
 name: thumbor
-version: 0.2.0
+version: 0.2.1

--- a/incubator/thumbor/templates/ingress.yaml
+++ b/incubator/thumbor/templates/ingress.yaml
@@ -27,11 +27,12 @@ spec:
     secretName: {{ template "fullname" $root }}-{{ .name }}-ssl
 {{- end }}
   rules:
+  {{- $ingress := . -}}
   {{- range .hosts }}
     - host: {{ . }}
       http:
         paths:
-          - path: {{ default "/" .path }}
+          - path: {{ $ingress.path | default "/" }}
             backend:
               serviceName: {{ template "fullname" $root }}
               servicePort: {{ $root.Values.service.externalPort }}


### PR DESCRIPTION
## what
* Get the path from outside of `range .hosts` so hosts can remains a list of strings.

## why
My change from #168 broke the thumbor chart in cases where you try to override the path.