### PR TITLE
[incubator/thumbor] add container probes

### DIFF
--- a/incubator/thumbor/Chart.yaml
+++ b/incubator/thumbor/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Thumbor+RemoteCV thumbnailing service
 name: thumbor
-version: 0.2.1
+version: 0.3.0

--- a/incubator/thumbor/templates/deployment.yaml
+++ b/incubator/thumbor/templates/deployment.yaml
@@ -28,7 +28,8 @@ spec:
         args:
           - "thumbor"
         ports:
-        - containerPort: {{ .Values.service.internalPort }}
+        - name: http
+          containerPort: {{ .Values.service.internalPort }}
         env:
         - name: ENGINE
           value: "opencv_engine"
@@ -86,3 +87,7 @@ spec:
           readOnly: false
         resources:
 {{ toYaml .Values.resources | indent 12 }}
+        livenessProbe:
+{{ toYaml .Values.livenessProbe | indent 10 }}
+        readinessProbe:
+{{ toYaml .Values.readinessProbe | indent 10 }}

--- a/incubator/thumbor/values.yaml
+++ b/incubator/thumbor/values.yaml
@@ -96,4 +96,23 @@ remotecv:
       cpu: 100m
       memory: 128Mi
 
-
+## Configure extra options for liveness and readiness probes
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
+livenessProbe:
+  httpGet:
+    path: /healthcheck
+    port: http
+  # initialDelaySeconds: 120
+  # periodSeconds: 10
+  # timeoutSeconds: 5
+  # failureThreshold: 6
+  # successThreshold: 1
+readinessProbe:
+  httpGet:
+    path: /healthcheck
+    port: http
+  # initialDelaySeconds: 30
+  # periodSeconds: 10
+  # timeoutSeconds: 5
+  # failureThreshold: 6
+  # successThreshold: 1


### PR DESCRIPTION
## what
* adds livenessProbe and readinessProbe
* name the container port "http" so it can be referenced by name

## why
* make it easier to rollout changes to the thumbor install without downtime
* naming ports helps reference them in other places (like probes)
* Thumbor has some info on the `/healthcheck` endpoint in [their docs](https://github.com/thumbor/thumbor/wiki/Hosting#production-environment) and they recommend if for use behind a load balancer (and K8s Services are kinda loadbalancers).