### PR TITLE
Extend usability of nginx-ingress chart

### DIFF
--- a/incubator/nginx-ingress/Chart.yaml
+++ b/incubator/nginx-ingress/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Nginx Ingress
 name: nginx-ingress
-version: 0.1.7
+version: 0.1.8

--- a/incubator/nginx-ingress/templates/configmap.yaml
+++ b/incubator/nginx-ingress/templates/configmap.yaml
@@ -17,3 +17,4 @@ data:
       {{ if $index }},{{ end }}{{ $element }}
     {{- end -}}
   "
+{{ toYaml .Values.configMap.options | indent 2 }}

--- a/incubator/nginx-ingress/templates/service.yaml
+++ b/incubator/nginx-ingress/templates/service.yaml
@@ -6,19 +6,29 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     k8s-addon: ingress-nginx.addons.k8s.io
     role: entrypoint
+{{- if or .Values.useProxyProtocol .Values.service.annotations }}
   annotations:
+  {{- if .Values.useProxyProtocol }}
+    service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: '*'
+  {{- end }}
+  {{- if .Values.service.annotations }}
 {{ toYaml .Values.service.annotations | indent 4 }}
+  {{- end }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:
+  {{- if .Values.service.httpIngressEnabled }}
   - name: http
-    targetPort: http
+    targetPort: {{ .Values.service.httpTargetPort }}
     port: {{ .Values.service.externalHttpPort }}
     protocol: TCP
-    
+  {{- end }}
+  {{- if .Values.service.httpsIngressEnabled }}
   - name: https
-    targetPort: https
+    targetPort: {{ .Values.service.httpsTargetPort }}
     port: {{ .Values.service.externalHttpsPort }}
     protocol: TCP
+  {{- end }}
   selector:
     app: {{ template "fullname" . }}

--- a/incubator/nginx-ingress/values.yaml
+++ b/incubator/nginx-ingress/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: "quay.io/kubernetes-ingress-controller/nginx-ingress-controller"
-  tag: "0.11.0"
+  tag: "0.15.0"
   pullPolicy: "IfNotPresent"
 
 service:
@@ -17,8 +17,15 @@ service:
   internalHttpPort: 80
   internalHttpsPort: 443
   internalHealthzPort: 18080
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: '*'
+  httpTargetPort: http
+  httpsTargetPort: https
+  httpIngressEnabled: true
+  httpsIngressEnabled: true
+## If you have custom annotations go here, for example:
+#  annotations:
+#    service.beta.kubernetes.io/aws-load-balancer-extra-security-groups: "sg-1234567890"
+#    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
+#    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
 
 resources:
   limits:
@@ -39,6 +46,12 @@ customHttpErrors:
     - "502"
     - "503"
     - "504"
+
+## If you are using any additional nginx configmap customization, those values go here
+configMap:
+  options:
+    ## This is a default value and accepts a CIDR range, if you have multiple values they should be comma separated
+    nginx-status-ipv4-whitelist: "127.0.0.1"
 
 nginx-default-backend:
   replicaCount: 1

--- a/incubator/nginx-ingress/values.yaml
+++ b/incubator/nginx-ingress/values.yaml
@@ -21,7 +21,7 @@ service:
   httpsTargetPort: https
   httpIngressEnabled: true
   httpsIngressEnabled: true
-## If you have custom annotations go here, for example:
+## If you have custom annotations they go here, for example:
 #  annotations:
 #    service.beta.kubernetes.io/aws-load-balancer-extra-security-groups: "sg-1234567890"
 #    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http


### PR DESCRIPTION
## What it is

- Extends the usability of the chart by adding in conditionals for some of the more modern nginx-ingress features

## Why 

- The big why here is making this chart usable when terminating SSL at an ELB. The [example](https://github.com/kubernetes/ingress-nginx/blob/master/deploy/provider/aws/service-l7.yaml) on the main repo shows that when terminating SSL at the ELB level, the target port for https rules should be the http port (specified as `http`, not `80`). 
- When terminating SSL at the ELB level, proxy protocol should be disabled, previously this chart had `service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: '*'` hard coded as a value, I implemented a minor change in the design of the chart to include this annotation in the service so long as use-proxy-protocol is set to `true` (it is by default still). This annotation should not be added while terminating SSL at an ELB.
- Upgrading the default version to 0.15.0 brings some general bug fixes to the nginx image as well as the option to change the whitelist ips for the nginx status check which comes in handy. 
- Making the port rules optional in the service (ie: no http rule) allows users to only have open what they want open at the ELB layer, if no http traffic is going through, then it shouldn't be there.

## Backwards compatability

- Outside of the upgrade to the container default version, none. I have been using 0.15.0 in multiple environments for some time now without issue.