### PR TITLE
[incubator/monochart] Support multiple cronjobs

### DIFF
--- a/incubator/monochart/Chart.yaml
+++ b/incubator/monochart/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A declarative helm chart for deploying common types of services on Kubernetes
 name: monochart
-version: 0.6.2
-appVersion: 0.6.2
+version: 0.7.0
+appVersion: 0.7.0
 home: https://github.com/cloudposse/charts/tree/master/incubator/monochart
 icon: https://raw.githubusercontent.com/cloudposse/charts/master/incubator/monochart/logo.png
 maintainers:

--- a/incubator/monochart/templates/cronjob.yaml
+++ b/incubator/monochart/templates/cronjob.yaml
@@ -1,6 +1,7 @@
 {{- $root := . -}}
 {{- range $name, $cron := .Values.cronjob -}}
 {{- if $cron.enabled -}}
+---
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:

--- a/incubator/monochart/templates/cronjob.yaml
+++ b/incubator/monochart/templates/cronjob.yaml
@@ -1,72 +1,73 @@
-{{- if .Values.cronjob -}}
-{{- if .Values.cronjob.enabled -}}
+{{- $root := . -}}
+{{- $name,$cron := range $cron }}
+{{- if $cron.enabled -}}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ include "common.fullname" . }}
-{{- with .Values.cronjob.annotations }}
+  name: {{ include "common.fullname" $root }}-{{ $name }}
+{{- with $cron.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
   labels:
-{{ include "common.labels.standard" . | indent 4 }}
-{{- with .Values.cronjob.labels }}
+{{ include "common.labels.standard" $root | indent 4 }}
+{{- with $cron.labels }}
 {{ toYaml .| indent 4 }}
 {{- end }}
 spec:
-  successfulJobsHistoryLimit: {{ default 1 .Values.cronjob.successfulJobsHistoryLimit }}
-  failedJobsHistoryLimit: {{ default 1 .Values.cronjob.failedJobsHistoryLimit }}
-  concurrencyPolicy: {{ default "Forbid" .Values.cronjob.concurrencyPolicy }}
-  schedule: '{{ required "Schedule required!" .Values.cronjob.schedule }}'
+  successfulJobsHistoryLimit: {{ default 1 $cron.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ default 1 $cron.failedJobsHistoryLimit }}
+  concurrencyPolicy: {{ default "Forbid" $cron.concurrencyPolicy }}
+  schedule: '{{ required "Schedule required!" $cron.schedule }}'
   jobTemplate:
     spec:
-      activeDeadlineSeconds: {{ default 300 .Values.cronjob.activeDeadlineSeconds }}
+      activeDeadlineSeconds: {{ default 300 $cron.activeDeadlineSeconds }}
       template:
         metadata:
-          name: {{ include "common.fullname" . }}
-{{- with .Values.cronjob.pod.annotations }}
+          name: {{ include "common.fullname" $root }}-{{ $name }}
+{{- with $cron.pod.annotations }}
           annotations:
 {{ toYaml . | indent 12 }}
 {{- end }}
           labels:
-            app: {{ include "common.name" . }}
-            release: {{ .Release.Name | quote }}
-{{- with .Values.cronjob.pod.labels }}
+            app: {{ include "common.name" $root }}
+            release: {{ $root.Release.Name | quote }}
+{{- with $cron.pod.labels }}
 {{ toYaml .| indent 12 }}
 {{- end }}
         spec:
-          restartPolicy: '{{ default "Never" .Values.cronjob.restartPolicy }}'
+          restartPolicy: '{{ default "Never" $cron.restartPolicy }}'
           containers:
-          - name: {{ .Chart.Name }}
-            image: {{ required "image.repository is required!" .Values.image.repository }}:{{ required "image.tag is required!" .Values.image.tag }}
-            imagePullPolicy: {{ .Values.image.pullPolicy }}
-{{ include "monochart.env" . | indent 12 }}
-            args: {{ .Values.cronjob.pod.args }}
+          - name: {{ include "common.name" $root }}
+            image: {{ required "image.repository is required!" $root.Values.image.repository }}:{{ required "image.tag is required!" $root.Values.image.tag }}
+            imagePullPolicy: {{ $root.Values.image.pullPolicy }}
+{{ include "monochart.env" $root | indent 12 }}
+            args: {{ $cron.pod.args }}
             volumeMounts:
             - mountPath: /data
               name: storage
-{{ include "monochart.files.volumeMounts" . | indent 12 }}
-{{- with .Values.resources }}
+{{ include "monochart.files.volumeMounts" $root | indent 12 }}
+{{- with $root.Values.resources }}
             resources:
 {{ toYaml . | indent 14 }}
 {{- end }}
           imagePullSecrets:
-{{- if .Values.dockercfg.enabled }}
-            - name: {{ include "common.fullname" . }}
+{{- if $root.Values.dockercfg.enabled }}
+            - name: {{ include "common.fullname" $root }}
 {{- end }}
-{{- with .Values.image.pullSecrets }}
+{{- with $root.Values.image.pullSecrets }}
 {{- range . }}
             - name: {{ . }}
 {{- end }}
 {{- end }}
           volumes:
           - name: storage
-{{- if .Values.persistence.enabled }}
+{{- if $root.Values.persistence.enabled }}
             persistentVolumeClaim:
-              claimName: {{ .Values.persistence.existingClaim | default (include "common.fullname" .) }}
+              claimName: {{ $root.Values.persistence.existingClaim | default (include "common.fullname" $root) }}
 {{- else }}
             emptyDir: {}
 {{- end }}
-{{ include "monochart.files.volumes" . | indent 10 }}
+{{ include "monochart.files.volumes" $root | indent 10 }}
 {{- end -}}
 {{- end -}}

--- a/incubator/monochart/templates/cronjob.yaml
+++ b/incubator/monochart/templates/cronjob.yaml
@@ -1,5 +1,5 @@
 {{- $root := . -}}
-{{- $name,$cron := range $cron }}
+{{- range $name, $cron := .Values.cronjob -}}
 {{- if $cron.enabled -}}
 apiVersion: batch/v1beta1
 kind: CronJob

--- a/incubator/monochart/templates/cronjob.yaml
+++ b/incubator/monochart/templates/cronjob.yaml
@@ -5,7 +5,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ include "common.fullname" $root }}-{{ $name }}
+  name: {{ include "common.fullname" $root }}-{{ $name | replace "_" "-"  }}
 {{- with $cron.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
@@ -25,7 +25,7 @@ spec:
       activeDeadlineSeconds: {{ default 300 $cron.activeDeadlineSeconds }}
       template:
         metadata:
-          name: {{ include "common.fullname" $root }}-{{ $name }}
+          name: {{ include "common.fullname" $root }}-{{ $name | replace "_" "-"  }}
 {{- with $cron.pod.annotations }}
           annotations:
 {{ toYaml . | indent 12 }}

--- a/incubator/monochart/templates/cronjob.yaml
+++ b/incubator/monochart/templates/cronjob.yaml
@@ -1,6 +1,6 @@
 {{- $root := . -}}
 {{- range $name, $cron := .Values.cronjob -}}
-{{- if $cron.enabled -}}
+{{- if $cron.enabled }}
 ---
 apiVersion: batch/v1beta1
 kind: CronJob

--- a/incubator/monochart/templates/daemonset.yaml
+++ b/incubator/monochart/templates/daemonset.yaml
@@ -33,6 +33,7 @@ spec:
       labels:
         app: {{ include "common.name" . }}
         release: {{ .Release.Name | quote }}
+        serve: true
 {{- with .Values.daemonset.pod.labels }}
 {{ toYaml .| indent 8 }}
 {{- end }}

--- a/incubator/monochart/templates/daemonset.yaml
+++ b/incubator/monochart/templates/daemonset.yaml
@@ -45,9 +45,11 @@ spec:
 {{ include "monochart.env" . | indent 8 }}
         args: {{ .Values.daemonset.pod.args }}
         ports:
-          - name: http
-            containerPort: {{ .Values.service.internalPort }}
-            protocol: TCP
+{{- range $name, $port := .Values.service.ports }}
+        - name: {{ $name }}
+          containerPort: {{ $port.internal }}
+          protocol: {{ default "TCP" $port.protocol  }}
+{{- end }}
         volumeMounts:
         - mountPath: /data
           name: storage

--- a/incubator/monochart/templates/daemonset.yaml
+++ b/incubator/monochart/templates/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
       labels:
         app: {{ include "common.name" . }}
         release: {{ .Release.Name | quote }}
-        serve: true
+        serve: "true"
 {{- with .Values.daemonset.pod.labels }}
 {{ toYaml .| indent 8 }}
 {{- end }}

--- a/incubator/monochart/templates/deployment.yaml
+++ b/incubator/monochart/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
       labels:
         app: {{ include "common.name" . }}
         release: {{ .Release.Name | quote }}
-        serve: true
+        serve: "true"
 {{- if .Values.deployment.pod}}
 {{- with .Values.deployment.pod.labels }}
 {{ toYaml .| indent 8 }}

--- a/incubator/monochart/templates/deployment.yaml
+++ b/incubator/monochart/templates/deployment.yaml
@@ -51,9 +51,11 @@ spec:
 {{ include "monochart.env" . | indent 8 }}
         {{if .Values.deployment.pod}}args: {{ .Values.deployment.pod.args }}{{- end }}
         ports:
-          - name: http
-            containerPort: {{ .Values.service.internalPort }}
-            protocol: TCP
+{{- range $name, $port := .Values.service.ports }}
+          - name: {{ $name }}
+            containerPort: {{ $port.internal }}
+            protocol: {{ default "TCP" $port.protocol  }}
+{{- end }}
         volumeMounts:
         - mountPath: /data
           name: storage

--- a/incubator/monochart/templates/deployment.yaml
+++ b/incubator/monochart/templates/deployment.yaml
@@ -37,6 +37,7 @@ spec:
       labels:
         app: {{ include "common.name" . }}
         release: {{ .Release.Name | quote }}
+        serve: true
 {{- if .Values.deployment.pod}}
 {{- with .Values.deployment.pod.labels }}
 {{ toYaml .| indent 8 }}

--- a/incubator/monochart/templates/ingress.yaml
+++ b/incubator/monochart/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $servicePort := .Values.service.externalPort -}}
 {{- $serviceName := include "common.fullname" . -}}
 {{- range $name, $ingress := .Values.ingress -}}
-{{- if $ingress.enabled -}}
+{{- if $ingress.enabled }}
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress

--- a/incubator/monochart/templates/ingress.yaml
+++ b/incubator/monochart/templates/ingress.yaml
@@ -1,25 +1,26 @@
 {{- $root := . -}}
 {{- $servicePort := .Values.service.externalPort -}}
 {{- $serviceName := include "common.fullname" . -}}
-{{- range .Values.ingress }}
+{{- range $name, $ingress := .Values.ingress -}}
+{{- if $ingress.enabled -}}
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-{{- with .annotations }}
+{{- with $ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
   labels:
-{{- with .labels }}
+{{- with $ingress.labels }}
 {{ toYaml . | indent 4 }}
 {{- end }}
 {{ include "common.labels.standard" $root | indent 4 }}
-    ingressName: {{ .name }}
-  name: {{ include "common.fullname" $root }}-{{ .name }}
+    ingressName: {{ $name }}
+  name: {{ include "common.fullname" $root }}-{{ $name }}
 spec:
   rules:
-{{- range $host, $path := .hosts }}
+{{- range $host, $path := $ingress.hosts }}
     - host: {{ $host }}
       http:
         paths:
@@ -28,8 +29,9 @@ spec:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
 {{- end -}}
-{{- with .tls }}
+{{- with $ingress.tls }}
   tls:
 {{ toYaml . | indent 4 }}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/incubator/monochart/templates/ingress.yaml
+++ b/incubator/monochart/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- $root := . -}}
-{{- $servicePort := .Values.service.externalPort -}}
+{{- $servicePort := .Values.service.ports.default.external -}}
 {{- $serviceName := include "common.fullname" . -}}
 {{- range $name, $ingress := .Values.ingress -}}
 {{- if $ingress.enabled }}

--- a/incubator/monochart/templates/job.yaml
+++ b/incubator/monochart/templates/job.yaml
@@ -5,7 +5,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "common.fullname" $root }}-{{ $name }}
+  name: {{ include "common.fullname" $root }}-{{ $name | replace "_" "-"  }}
 {{- with $job.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
@@ -19,7 +19,7 @@ spec:
   activeDeadlineSeconds: {{ default 300 $job.activeDeadlineSeconds }}
   template:
     metadata:
-      name: {{ include "common.fullname" $root }}-{{ $name }}
+      name: {{ include "common.fullname" $root }}-{{ $name | replace "_" "-"  }}
 {{- with $job.pod.annotations }}
       annotations:
 {{ toYaml . | indent 8 }}

--- a/incubator/monochart/templates/job.yaml
+++ b/incubator/monochart/templates/job.yaml
@@ -1,66 +1,67 @@
-{{- if .Values.job -}}
-{{- if .Values.job.enabled -}}
+{{- $root := . -}}
+{{- $name,$job := range .Values.job }}
+{{- if $job.enabled -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "common.fullname" . }}
-{{- with .Values.job.annotations }}
+  name: {{ include "common.fullname" $root }}-{{ $name }}
+{{- with $job.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
   labels:
-{{ include "common.labels.standard" . | indent 4 }}
-{{- with .Values.job.labels }}
-{{ toYaml .| indent 4 }}
+{{ include "common.labels.standard" $root | indent 4 }}
+{{- with $job.labels }}
+{{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-  activeDeadlineSeconds: {{ default 300 .Values.job.activeDeadlineSeconds }}
+  activeDeadlineSeconds: {{ default 300 $job.activeDeadlineSeconds }}
   template:
     metadata:
-      name: {{ include "common.fullname" . }}
-{{- with .Values.job.pod.annotations }}
+      name: {{ include "common.fullname" $root }}-{{ $name }}
+{{- with $job.pod.annotations }}
       annotations:
 {{ toYaml . | indent 8 }}
 {{- end }}
       labels:
-        app: {{ include "common.name" . }}
-        release: {{ .Release.Name | quote }}
-{{- with .Values.job.pod.labels }}
+        app: {{ include "common.name" $root }}
+        release: {{ $root.Release.Name | quote }}
+{{- with $job.pod.labels }}
 {{ toYaml .| indent 8 }}
 {{- end }}
     spec:
-      restartPolicy: '{{ default "Never" .Values.job.restartPolicy }}'
+      restartPolicy: '{{ default "Never" $job.restartPolicy }}'
       containers:
-      - name: {{ include "common.name" . }}
-        image: {{ required "image.repository is required!" .Values.image.repository }}:{{ required "image.tag is required!" .Values.image.tag }}
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-{{ include "monochart.env" . | indent 8 }}
-        args: {{ .Values.job.pod.args }}
+      - name: {{ include "common.name" $root }}
+        image: {{ required "image.repository is required!" $root.Values.image.repository }}:{{ required "image.tag is required!" $root.Values.image.tag }}
+        imagePullPolicy: {{ $root.Values.image.pullPolicy }}
+{{ include "monochart.env" $root | indent 8 }}
+        args: {{ $job.pod.args }}
         volumeMounts:
         - mountPath: /data
           name: storage
-{{ include "monochart.files.volumeMounts" . | indent 8 }}
-{{- with .Values.resources }}
+{{ include "monochart.files.volumeMounts" $root | indent 8 }}
+{{- with $root.Values.resources }}
         resources:
 {{ toYaml . | indent 10 }}
 {{- end }}
       imagePullSecrets:
-{{- if .Values.dockercfg.enabled }}
-        - name: {{ include "common.fullname" . }}
+{{- if $root.Values.dockercfg.enabled }}
+        - name: {{ include "common.fullname" $root }}
 {{- end }}
-{{- with .Values.image.pullSecrets }}
+{{- with $root.Values.image.pullSecrets }}
       {{- range . }}
         - name: {{ . }}
       {{- end }}
 {{- end }}
       volumes:
       - name: storage
-      {{- if .Values.persistence.enabled }}
+      {{- if $root.Values.persistence.enabled }}
         persistentVolumeClaim:
-          claimName: {{ .Values.persistence.existingClaim | default (include "common.fullname" .) }}
+          claimName: {{ $root.Values.persistence.existingClaim | default (include "common.fullname" $root) }}
       {{- else }}
         emptyDir: {}
       {{- end }}
-{{ include "monochart.files.volumes" . | indent 6 }}
+{{ include "monochart.files.volumes" $root | indent 6 }}
 {{- end -}}
 {{- end -}}

--- a/incubator/monochart/templates/job.yaml
+++ b/incubator/monochart/templates/job.yaml
@@ -1,6 +1,7 @@
 {{- $root := . -}}
 {{- range $name, $job := .Values.job -}}
 {{- if $job.enabled -}}
+---
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/incubator/monochart/templates/job.yaml
+++ b/incubator/monochart/templates/job.yaml
@@ -1,5 +1,5 @@
 {{- $root := . -}}
-{{- $name,$job := range .Values.job }}
+{{- range $name, $job := .Values.job -}}
 {{- if $job.enabled -}}
 apiVersion: batch/v1
 kind: Job

--- a/incubator/monochart/templates/job.yaml
+++ b/incubator/monochart/templates/job.yaml
@@ -1,6 +1,6 @@
 {{- $root := . -}}
 {{- range $name, $job := .Values.job -}}
-{{- if $job.enabled -}}
+{{- if $job.enabled }}
 ---
 apiVersion: batch/v1
 kind: Job

--- a/incubator/monochart/templates/service.yaml
+++ b/incubator/monochart/templates/service.yaml
@@ -22,4 +22,5 @@ spec:
   selector:
     app: {{ include "common.name" . }}
     release: {{ .Release.Name }}
+    serve: true
 {{- end -}}

--- a/incubator/monochart/templates/service.yaml
+++ b/incubator/monochart/templates/service.yaml
@@ -15,10 +15,12 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.externalPort }}
-      targetPort: http
-      protocol: TCP
-      name: http
+{{- range $name, $port := .Values.service.ports }}
+    - port: {{ $port.external }}
+      targetPort: {{ $name }}
+      protocol: {{ default "TCP" $port.protocol  }}
+      name: {{ $name }}
+{{- end }}
   selector:
     app: {{ include "common.name" . }}
     release: {{ .Release.Name }}

--- a/incubator/monochart/templates/service.yaml
+++ b/incubator/monochart/templates/service.yaml
@@ -16,13 +16,13 @@ spec:
   type: {{ .Values.service.type }}
   ports:
 {{- range $name, $port := .Values.service.ports }}
-    - port: {{ $port.external }}
-      targetPort: {{ $name }}
-      protocol: {{ default "TCP" $port.protocol  }}
-      name: {{ $name }}
+  - port: {{ $port.external }}
+    targetPort: {{ $name }}
+    protocol: {{ default "TCP" $port.protocol  }}
+    name: {{ $name }}
 {{- end }}
   selector:
     app: {{ include "common.name" . }}
     release: {{ .Release.Name }}
-    serve: true
+    serve: "true"
 {{- end -}}

--- a/incubator/monochart/templates/statefulset.yaml
+++ b/incubator/monochart/templates/statefulset.yaml
@@ -48,9 +48,11 @@ spec:
 {{ include "monochart.env" . | indent 8 }}
         args: {{ .Values.statefulset.pod.args }}
         ports:
-          - name: http
-            containerPort: {{ .Values.service.internalPort }}
-            protocol: TCP
+{{- range $name, $port := .Values.service.ports }}
+        - name: {{ $name }}
+          containerPort: {{ $port.internal }}
+          protocol: {{ default "TCP" $port.protocol  }}
+{{- end }}
         volumeMounts:
         - mountPath: /data
           name: storage

--- a/incubator/monochart/templates/statefulset.yaml
+++ b/incubator/monochart/templates/statefulset.yaml
@@ -35,6 +35,7 @@ spec:
       labels:
         app: {{ include "common.name" . }}
         release: {{ .Release.Name | quote }}
+        serve: true
 {{- with .Values.statefulset.pod.labels }}
 {{ toYaml .| indent 4 }}
 {{- end }}

--- a/incubator/monochart/templates/statefulset.yaml
+++ b/incubator/monochart/templates/statefulset.yaml
@@ -35,7 +35,7 @@ spec:
       labels:
         app: {{ include "common.name" . }}
         release: {{ .Release.Name | quote }}
-        serve: true
+        serve: "true"
 {{- with .Values.statefulset.pod.labels }}
 {{ toYaml .| indent 4 }}
 {{- end }}

--- a/incubator/monochart/values.yaml
+++ b/incubator/monochart/values.yaml
@@ -107,37 +107,39 @@ daemonset:
     args: []
 
 job:
-  enabled: false
-  # labels:
-  #   name: value
-  # annotations:
-  #   name: value
-  restartPolicy: Never
-  pod:
-    annotations: {}
-    ## Read more about kube2iam to provide access to s3 https://github.com/jtblin/kube2iam
-    #  iam.amazonaws.com/role: role-arn
-    labels: {}
-    args: []
+  default:
+    enabled: false
+    # labels:
+    #   name: value
+    # annotations:
+    #   name: value
+    restartPolicy: Never
+    pod:
+      annotations: {}
+      ## Read more about kube2iam to provide access to s3 https://github.com/jtblin/kube2iam
+      #  iam.amazonaws.com/role: role-arn
+      labels: {}
+      args: []
 
 cronjob:
-  enabled: false
-  # labels:
-  #   name: value
-  # annotations:
-  #   name: value
-  successfulJobsHistoryLimit: 1
-  failedJobsHistoryLimit: 1
-  concurrencyPolicy: Forbid
-  schedule: "* * */15 * *"
-  activeDeadlineSeconds: 300
-  restartPolicy: Never
-  pod:
-    annotations: {}
-    ## Read more about kube2iam to provide access to s3 https://github.com/jtblin/kube2iam
-    #  iam.amazonaws.com/role: role-arn
-    labels: {}
-    args: []
+  default:
+    enabled: false
+    # labels:
+    #   name: value
+    # annotations:
+    #   name: value
+    successfulJobsHistoryLimit: 1
+    failedJobsHistoryLimit: 1
+    concurrencyPolicy: Forbid
+    schedule: "* * */15 * *"
+    activeDeadlineSeconds: 300
+    restartPolicy: Never
+    pod:
+      annotations: {}
+      ## Read more about kube2iam to provide access to s3 https://github.com/jtblin/kube2iam
+      #  iam.amazonaws.com/role: role-arn
+      labels: {}
+      args: []
 
 service:
   enabled: false

--- a/incubator/monochart/values.yaml
+++ b/incubator/monochart/values.yaml
@@ -145,7 +145,7 @@ service:
   enabled: false
   type: ClusterIP
   ports:
-    http:
+    default:
       internal: 8080
       external: 80
   # labels:

--- a/incubator/monochart/values.yaml
+++ b/incubator/monochart/values.yaml
@@ -144,8 +144,10 @@ cronjob:
 service:
   enabled: false
   type: ClusterIP
-  internalPort: 8080
-  externalPort: 80
+  ports:
+    http:
+      internal: 8080
+      external: 80
   # labels:
   #   name: value
   # annotations:

--- a/incubator/monochart/values.yaml
+++ b/incubator/monochart/values.yaml
@@ -296,31 +296,19 @@ persistence:
   ##
   # storageClass: "-"
 
-## Ingress for load balancer
-# ingress:
-# - name: "default"
-## Ingress labels
-##
-#   labels:
-#     dns: "route53"
-
-## Ingress annotations
-##
-#   annotations:
-#     kubernetes.io/ingress.class: nginx
-#     kubernetes.io/tls-acme: "true"
-
-## Ingress hostnames
-## Must be provided if Ingress is enabled
-##
-#   hosts:
-#     "domain.com": /
-#     "www.domain.com": /
-
-## Ingress TLS configuration
-## Secrets must be manually created in the namespace
-##
-#   tls:
-#   - secretName: server-tls
-#     hosts:
-#     - domain.com
+# Ingress for load balancer
+ingress:
+  default:
+    enabled: false
+#    labels:
+#      dns: "route53"
+#    annotations:
+#      kubernetes.io/ingress.class: nginx
+#      kubernetes.io/tls-acme: "true"
+#    hosts:
+#      "domain.com": /
+#      "www.domain.com": /
+#    tls:
+#    - secretName: server-tls
+#      hosts:
+#      - domain.com


### PR DESCRIPTION
## What
* Support multiple jobs
* Support multiple cron jobs
* Standardize ingress declaration
* Make service select pods only from Deployment, Deamonset and Statefull Set
* Made service support multiple ports

## Why
* To have multiple jobs - for example `on install\update` and `on delete`
* To have multiple cron jobs
* To use the same way declare list of resources
* To solve problems when Service selects running jobs
* In case pods need several ports to be listen
