### PR TITLE
[monochart] Add `container.command`

### DIFF
--- a/incubator/monochart/Chart.yaml
+++ b/incubator/monochart/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A declarative helm chart for deploying common types of services on Kubernetes
 name: monochart
-version: 0.7.0
-appVersion: 0.7.0
+version: 0.8.0
+appVersion: 0.8.0
 home: https://github.com/cloudposse/charts/tree/master/incubator/monochart
 icon: https://raw.githubusercontent.com/cloudposse/charts/master/incubator/monochart/logo.png
 maintainers:

--- a/incubator/monochart/templates/cronjob.yaml
+++ b/incubator/monochart/templates/cronjob.yaml
@@ -43,6 +43,9 @@ spec:
             image: {{ required "image.repository is required!" $root.Values.image.repository }}:{{ required "image.tag is required!" $root.Values.image.tag }}
             imagePullPolicy: {{ $root.Values.image.pullPolicy }}
 {{ include "monochart.env" $root | indent 12 }}
+            {{- if $cron.pod.command }}
+            command: {{ $cron.pod.command }}
+            {{- end }}
             args: {{ $cron.pod.args }}
             volumeMounts:
             - mountPath: /data

--- a/incubator/monochart/templates/daemonset.yaml
+++ b/incubator/monochart/templates/daemonset.yaml
@@ -43,6 +43,9 @@ spec:
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
 {{ include "monochart.env" . | indent 8 }}
+        {{- if .Values.daemonset.pod.command }}
+        command: {{ .Values.daemonset.pod.command }}
+        {{- end }}
         args: {{ .Values.daemonset.pod.args }}
         ports:
 {{- range $name, $port := .Values.service.ports }}

--- a/incubator/monochart/templates/deployment.yaml
+++ b/incubator/monochart/templates/deployment.yaml
@@ -49,7 +49,12 @@ spec:
         image: {{ required "image.repository is required!" .Values.image.repository }}:{{ required "image.tag is required!" .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
 {{ include "monochart.env" . | indent 8 }}
-        {{if .Values.deployment.pod}}args: {{ .Values.deployment.pod.args }}{{- end }}
+        {{- if .Values.deployment.pod.command }}
+        command: {{ .Values.deployment.pod.command }}
+        {{- end }}
+        {{- if .Values.deployment.pod.args }}
+        args: {{ .Values.deployment.pod.args }}
+        {{- end }}
         ports:
 {{- range $name, $port := .Values.service.ports }}
           - name: {{ $name }}

--- a/incubator/monochart/templates/job.yaml
+++ b/incubator/monochart/templates/job.yaml
@@ -37,6 +37,9 @@ spec:
         image: {{ required "image.repository is required!" $root.Values.image.repository }}:{{ required "image.tag is required!" $root.Values.image.tag }}
         imagePullPolicy: {{ $root.Values.image.pullPolicy }}
 {{ include "monochart.env" $root | indent 8 }}
+        {{- if $job.pod.command }}
+        command: {{ $job.pod.command }}
+        {{- end }}
         args: {{ $job.pod.args }}
         volumeMounts:
         - mountPath: /data

--- a/incubator/monochart/templates/statefulset.yaml
+++ b/incubator/monochart/templates/statefulset.yaml
@@ -46,6 +46,9 @@ spec:
         image: {{ required "image.repository is required!" .Values.image.repository }}:{{ required "image.tag is required!" .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
 {{ include "monochart.env" . | indent 8 }}
+        {{- if .Values.statefulset.pod.command }}
+        command: {{ .Values.statefulset.pod.command }}
+        {{- end }}
         args: {{ .Values.statefulset.pod.args }}
         ports:
 {{- range $name, $port := .Values.service.ports }}

--- a/incubator/monochart/values.yaml
+++ b/incubator/monochart/values.yaml
@@ -59,7 +59,7 @@ deployment:
   enabled: false
   ## Pods replace strategy
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
-  # strategy: {}    
+  # strategy: {}
   revisionHistoryLimit: 10
   # annotations:
   #   name: value
@@ -70,13 +70,14 @@ deployment:
     ## Read more about kube2iam to provide access to s3 https://github.com/jtblin/kube2iam
     #  iam.amazonaws.com/role: role-arn
     labels: {}
+    # command:
     args: []
 
 statefulset:
   enabled: false
   ## Pods replace strategy
   ## ref: https://v1-10.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#statefulsetupdatestrategy-v1-apps
-  # strategy: {}    
+  # strategy: {}
   revisionHistoryLimit: 10
   # annotations:
   #   name: value
@@ -87,13 +88,14 @@ statefulset:
     ## Read more about kube2iam to provide access to s3 https://github.com/jtblin/kube2iam
     #  iam.amazonaws.com/role: role-arn
     labels: {}
+    # command:
     args: []
 
 daemonset:
   enabled: false
   ## Pods replace strategy
   ## ref: https://v1-10.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#daemonsetupdatestrategy-v1-apps
-  # strategy: {}    
+  # strategy: {}
   revisionHistoryLimit: 10
   # annotations:
   #   name: value
@@ -104,6 +106,7 @@ daemonset:
     ## Read more about kube2iam to provide access to s3 https://github.com/jtblin/kube2iam
     #  iam.amazonaws.com/role: role-arn
     labels: {}
+    # command:
     args: []
 
 job:
@@ -119,6 +122,7 @@ job:
       ## Read more about kube2iam to provide access to s3 https://github.com/jtblin/kube2iam
       #  iam.amazonaws.com/role: role-arn
       labels: {}
+      # command:
       args: []
 
 cronjob:
@@ -139,6 +143,7 @@ cronjob:
       ## Read more about kube2iam to provide access to s3 https://github.com/jtblin/kube2iam
       #  iam.amazonaws.com/role: role-arn
       labels: {}
+      # command:
       args: []
 
 service:


### PR DESCRIPTION
## what
* Add `container.command` to monochart's `cronjob`, `daemonset`, `deployment`, `job` and `statefulset`

## why
* To be able to override `ENTRYPOINT` from containers' Docker images
* Need to override `ENTRYPOINT` when, for example, deploying [`atlantis`](https://github.com/runatlantis/atlantis/blob/master/Dockerfile) and [`codefresh-cli`](https://github.com/codefresh-io/cli/blob/master/Dockerfile)

## references
* https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/
