### PR TITLE
[incubator/monochart] support security contexts and mount paths

### DIFF
--- a/incubator/monochart/Chart.yaml
+++ b/incubator/monochart/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A declarative helm chart for deploying common types of services on Kubernetes
 name: monochart
-version: 0.8.0
-appVersion: 0.8.0
+version: 0.8.1
+appVersion: 0.8.1
 home: https://github.com/cloudposse/charts/tree/master/incubator/monochart
 icon: https://raw.githubusercontent.com/cloudposse/charts/master/incubator/monochart/logo.png
 maintainers:

--- a/incubator/monochart/Chart.yaml
+++ b/incubator/monochart/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A declarative helm chart for deploying common types of services on Kubernetes
 name: monochart
-version: 0.8.1
-appVersion: 0.8.1
+version: 0.9.0
+appVersion: 0.9.0
 home: https://github.com/cloudposse/charts/tree/master/incubator/monochart
 icon: https://raw.githubusercontent.com/cloudposse/charts/master/incubator/monochart/logo.png
 maintainers:

--- a/incubator/monochart/templates/cronjob.yaml
+++ b/incubator/monochart/templates/cronjob.yaml
@@ -47,6 +47,10 @@ spec:
             command: {{ toYaml $cron.pod.command }}
             {{- end }}
             args: {{ toYaml $cron.pod.args }}
+{{- with $cron.pod.securityContext }}
+            securityContext:
+{{ toYaml . | indent 14 }}
+{{- end }}
             volumeMounts:
             - mountPath: {{ $root.Values.persistence.mountPath | quote }}
               name: storage

--- a/incubator/monochart/templates/cronjob.yaml
+++ b/incubator/monochart/templates/cronjob.yaml
@@ -44,9 +44,9 @@ spec:
             imagePullPolicy: {{ $root.Values.image.pullPolicy }}
 {{ include "monochart.env" $root | indent 12 }}
             {{- if $cron.pod.command }}
-            command: {{ $cron.pod.command }}
+            command: {{ toYaml $cron.pod.command }}
             {{- end }}
-            args: {{ $cron.pod.args }}
+            args: {{ toYaml $cron.pod.args }}
             volumeMounts:
             - mountPath: /data
               name: storage

--- a/incubator/monochart/templates/cronjob.yaml
+++ b/incubator/monochart/templates/cronjob.yaml
@@ -48,7 +48,7 @@ spec:
             {{- end }}
             args: {{ toYaml $cron.pod.args }}
             volumeMounts:
-            - mountPath: /data
+            - mountPath: {{ $root.Values.persistence.mountPath | quote }}
               name: storage
 {{ include "monochart.files.volumeMounts" $root | indent 12 }}
 {{- with $root.Values.resources }}

--- a/incubator/monochart/templates/daemonset.yaml
+++ b/incubator/monochart/templates/daemonset.yaml
@@ -54,7 +54,7 @@ spec:
           protocol: {{ default "TCP" $port.protocol  }}
 {{- end }}
         volumeMounts:
-        - mountPath: /data
+        - mountPath: {{ $root.Values.persistence.mountPath | quote }}
           name: storage
 {{ include "monochart.files.volumeMounts" . | indent 8 }}
 {{- with .Values.probes }}

--- a/incubator/monochart/templates/daemonset.yaml
+++ b/incubator/monochart/templates/daemonset.yaml
@@ -47,6 +47,10 @@ spec:
         command: {{ toYaml .Values.daemonset.pod.command }}
         {{- end }}
         args: {{ toYaml .Values.daemonset.pod.args }}
+{{- with .Values.daemonset.pod.securityContext }}
+        securityContext:
+{{ toYaml . | indent 10 }}
+{{- end }}
         ports:
 {{- range $name, $port := .Values.service.ports }}
         - name: {{ $name }}

--- a/incubator/monochart/templates/daemonset.yaml
+++ b/incubator/monochart/templates/daemonset.yaml
@@ -44,9 +44,9 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
 {{ include "monochart.env" . | indent 8 }}
         {{- if .Values.daemonset.pod.command }}
-        command: {{ .Values.daemonset.pod.command }}
+        command: {{ toYaml .Values.daemonset.pod.command }}
         {{- end }}
-        args: {{ .Values.daemonset.pod.args }}
+        args: {{ toYaml .Values.daemonset.pod.args }}
         ports:
 {{- range $name, $port := .Values.service.ports }}
         - name: {{ $name }}

--- a/incubator/monochart/templates/daemonset.yaml
+++ b/incubator/monochart/templates/daemonset.yaml
@@ -54,7 +54,7 @@ spec:
           protocol: {{ default "TCP" $port.protocol  }}
 {{- end }}
         volumeMounts:
-        - mountPath: {{ $root.Values.persistence.mountPath | quote }}
+        - mountPath: {{ .Values.persistence.mountPath | quote }}
           name: storage
 {{ include "monochart.files.volumeMounts" . | indent 8 }}
 {{- with .Values.probes }}

--- a/incubator/monochart/templates/deployment.yaml
+++ b/incubator/monochart/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
             protocol: {{ default "TCP" $port.protocol  }}
 {{- end }}
         volumeMounts:
-        - mountPath: /data
+        - mountPath: {{ $root.Values.persistence.mountPath | quote }}
           name: storage
 {{ include "monochart.files.volumeMounts" . | indent 8 }}
 {{- with .Values.probes }}

--- a/incubator/monochart/templates/deployment.yaml
+++ b/incubator/monochart/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
         {{- if .Values.deployment.pod.args }}
         args: {{ toYaml .Values.deployment.pod.args }}
         {{- end }}
-{{- with .Values.daemonset.pod.securityContext }}
+{{- with .Values.deployment.pod.securityContext }}
         securityContext:
 {{ toYaml . | indent 10 }}
 {{- end }}

--- a/incubator/monochart/templates/deployment.yaml
+++ b/incubator/monochart/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
             protocol: {{ default "TCP" $port.protocol  }}
 {{- end }}
         volumeMounts:
-        - mountPath: {{ $root.Values.persistence.mountPath | quote }}
+        - mountPath: {{ .Values.persistence.mountPath | quote }}
           name: storage
 {{ include "monochart.files.volumeMounts" . | indent 8 }}
 {{- with .Values.probes }}

--- a/incubator/monochart/templates/deployment.yaml
+++ b/incubator/monochart/templates/deployment.yaml
@@ -50,10 +50,10 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
 {{ include "monochart.env" . | indent 8 }}
         {{- if .Values.deployment.pod.command }}
-        command: {{ .Values.deployment.pod.command }}
+        command: {{ toYaml .Values.deployment.pod.command }}
         {{- end }}
         {{- if .Values.deployment.pod.args }}
-        args: {{ .Values.deployment.pod.args }}
+        args: {{ toYaml .Values.deployment.pod.args }}
         {{- end }}
         ports:
 {{- range $name, $port := .Values.service.ports }}

--- a/incubator/monochart/templates/deployment.yaml
+++ b/incubator/monochart/templates/deployment.yaml
@@ -55,6 +55,10 @@ spec:
         {{- if .Values.deployment.pod.args }}
         args: {{ toYaml .Values.deployment.pod.args }}
         {{- end }}
+{{- with .Values.daemonset.pod.securityContext }}
+        securityContext:
+{{ toYaml . | indent 10 }}
+{{- end }}
         ports:
 {{- range $name, $port := .Values.service.ports }}
           - name: {{ $name }}

--- a/incubator/monochart/templates/job.yaml
+++ b/incubator/monochart/templates/job.yaml
@@ -39,10 +39,10 @@ spec:
 {{ include "monochart.env" $root | indent 8 }}
         {{- if $job.pod.command }}
         command:
-          {{ toYaml $job.pod.command }}
+{{ toYaml $job.pod.command | indent 8}}
         {{- end }}
         args:
-          {{ toYaml $job.pod.args }}
+{{ toYaml $job.pod.args | indent 8 }}
         volumeMounts:
         - mountPath: /data
           name: storage

--- a/incubator/monochart/templates/job.yaml
+++ b/incubator/monochart/templates/job.yaml
@@ -38,9 +38,11 @@ spec:
         imagePullPolicy: {{ $root.Values.image.pullPolicy }}
 {{ include "monochart.env" $root | indent 8 }}
         {{- if $job.pod.command }}
-        command: {{ toYaml $job.pod.command }}
+        command:
+          {{ toYaml $job.pod.command }}
         {{- end }}
-        args: {{ toYaml $job.pod.args }}
+        args:
+          {{ toYaml $job.pod.args }}
         volumeMounts:
         - mountPath: /data
           name: storage

--- a/incubator/monochart/templates/job.yaml
+++ b/incubator/monochart/templates/job.yaml
@@ -38,9 +38,9 @@ spec:
         imagePullPolicy: {{ $root.Values.image.pullPolicy }}
 {{ include "monochart.env" $root | indent 8 }}
         {{- if $job.pod.command }}
-        command: {{ $job.pod.command }}
+        command: {{ toYaml $job.pod.command }}
         {{- end }}
-        args: {{ $job.pod.args }}
+        args: {{ toYaml $job.pod.args }}
         volumeMounts:
         - mountPath: /data
           name: storage

--- a/incubator/monochart/templates/job.yaml
+++ b/incubator/monochart/templates/job.yaml
@@ -43,6 +43,10 @@ spec:
         {{- end }}
         args:
 {{ toYaml $job.pod.args | indent 8 }}
+{{- with $job.pod.securityContext }}
+        securityContext:
+{{ toYaml . | indent 10 }}
+{{- end }}
         volumeMounts:
         - mountPath: {{ $root.Values.persistence.mountPath | quote }}
           name: storage

--- a/incubator/monochart/templates/job.yaml
+++ b/incubator/monochart/templates/job.yaml
@@ -44,7 +44,7 @@ spec:
         args:
 {{ toYaml $job.pod.args | indent 8 }}
         volumeMounts:
-        - mountPath: /data
+        - mountPath: {{ $root.Values.persistence.mountPath | quote }}
           name: storage
 {{ include "monochart.files.volumeMounts" $root | indent 8 }}
 {{- with $root.Values.resources }}

--- a/incubator/monochart/templates/statefulset.yaml
+++ b/incubator/monochart/templates/statefulset.yaml
@@ -47,9 +47,9 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
 {{ include "monochart.env" . | indent 8 }}
         {{- if .Values.statefulset.pod.command }}
-        command: {{ .Values.statefulset.pod.command }}
+        command: {{ toYaml .Values.statefulset.pod.command }}
         {{- end }}
-        args: {{ .Values.statefulset.pod.args }}
+        args: {{ toYaml .Values.statefulset.pod.args }}
         ports:
 {{- range $name, $port := .Values.service.ports }}
         - name: {{ $name }}

--- a/incubator/monochart/templates/statefulset.yaml
+++ b/incubator/monochart/templates/statefulset.yaml
@@ -57,7 +57,7 @@ spec:
           protocol: {{ default "TCP" $port.protocol  }}
 {{- end }}
         volumeMounts:
-        - mountPath: /data
+        - mountPath: {{ $root.Values.persistence.mountPath | quote }}
           name: storage
 {{ include "monochart.files.volumeMounts" . | indent 8 }}
 {{- with .Values.probes }}

--- a/incubator/monochart/templates/statefulset.yaml
+++ b/incubator/monochart/templates/statefulset.yaml
@@ -50,6 +50,10 @@ spec:
         command: {{ toYaml .Values.statefulset.pod.command }}
         {{- end }}
         args: {{ toYaml .Values.statefulset.pod.args }}
+{{- with .Values.daemonset.pod.securityContext }}
+        securityContext:
+{{ toYaml . | indent 10 }}
+{{- end }}
         ports:
 {{- range $name, $port := .Values.service.ports }}
         - name: {{ $name }}

--- a/incubator/monochart/templates/statefulset.yaml
+++ b/incubator/monochart/templates/statefulset.yaml
@@ -50,7 +50,7 @@ spec:
         command: {{ toYaml .Values.statefulset.pod.command }}
         {{- end }}
         args: {{ toYaml .Values.statefulset.pod.args }}
-{{- with .Values.daemonset.pod.securityContext }}
+{{- with .Values.statefulset.pod.securityContext }}
         securityContext:
 {{ toYaml . | indent 10 }}
 {{- end }}

--- a/incubator/monochart/templates/statefulset.yaml
+++ b/incubator/monochart/templates/statefulset.yaml
@@ -57,7 +57,7 @@ spec:
           protocol: {{ default "TCP" $port.protocol  }}
 {{- end }}
         volumeMounts:
-        - mountPath: {{ $root.Values.persistence.mountPath | quote }}
+        - mountPath: {{ .Values.persistence.mountPath | quote }}
           name: storage
 {{ include "monochart.files.volumeMounts" . | indent 8 }}
 {{- with .Values.probes }}

--- a/incubator/monochart/values.yaml
+++ b/incubator/monochart/values.yaml
@@ -282,6 +282,7 @@ resources:
 
 persistence:
   enabled: false
+  mountPath: /data
   accessMode: ReadWriteOnce
   size: 8Gi
   # annotations:

--- a/incubator/monochart/values.yaml
+++ b/incubator/monochart/values.yaml
@@ -66,6 +66,7 @@ deployment:
   # labels:
   #   name: value
   pod:
+    # securityContext: {}
     annotations: {}
     ## Read more about kube2iam to provide access to s3 https://github.com/jtblin/kube2iam
     #  iam.amazonaws.com/role: role-arn
@@ -84,6 +85,7 @@ statefulset:
   # labels:
   #   name: value
   pod:
+    # securityContext: {}
     annotations: {}
     ## Read more about kube2iam to provide access to s3 https://github.com/jtblin/kube2iam
     #  iam.amazonaws.com/role: role-arn
@@ -102,6 +104,7 @@ daemonset:
   # labels:
   #   name: value
   pod:
+    # securityContext: {}
     annotations: {}
     ## Read more about kube2iam to provide access to s3 https://github.com/jtblin/kube2iam
     #  iam.amazonaws.com/role: role-arn
@@ -118,6 +121,7 @@ job:
     #   name: value
     restartPolicy: Never
     pod:
+      # securityContext: {}
       annotations: {}
       ## Read more about kube2iam to provide access to s3 https://github.com/jtblin/kube2iam
       #  iam.amazonaws.com/role: role-arn
@@ -139,6 +143,7 @@ cronjob:
     activeDeadlineSeconds: 300
     restartPolicy: Never
     pod:
+      # securityContext: {}
       annotations: {}
       ## Read more about kube2iam to provide access to s3 https://github.com/jtblin/kube2iam
       #  iam.amazonaws.com/role: role-arn


### PR DESCRIPTION
## What
* Added security context for pods
* Made persistent volume mount path configurable

## Why
* For some apps (ex.: openvpn) security context is required 
* Some apps does not allow you to config path for persistent storage, so chart should allow mount the volume any dir