### PR TITLE
[monochart] Add `volumeClaimTemplates` to `statefulset`

### DIFF
--- a/incubator/monochart/Chart.yaml
+++ b/incubator/monochart/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A declarative helm chart for deploying common types of services on Kubernetes
 name: monochart
-version: 0.9.0
-appVersion: 0.9.0
+version: 0.10.0
+appVersion: 0.10.0
 home: https://github.com/cloudposse/charts/tree/master/incubator/monochart
 icon: https://raw.githubusercontent.com/cloudposse/charts/master/incubator/monochart/logo.png
 maintainers:

--- a/incubator/monochart/LICENSE
+++ b/incubator/monochart/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018, Cloud Posse, LLC
+   Copyright 2018-2019, Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/incubator/monochart/templates/_helpers.tpl
+++ b/incubator/monochart/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/* vim: set filetype=mustache: */}}
 
 {{/*
-Fullname of configMap/secret that contains environment vaiables.
+Fullname of configMap/secret that contains environment vaiables
 */}}
 {{- define "monochart.env.fullname" -}}
 {{- $root := index . 0 -}}
@@ -10,7 +10,7 @@ Fullname of configMap/secret that contains environment vaiables.
 {{- end -}}
 
 {{/*
-Fullname of configMap/secret that contains files.
+Fullname of configMap/secret that contains files
 */}}
 {{- define "monochart.files.fullname" -}}
 {{- $root := index . 0 -}}

--- a/incubator/monochart/templates/statefulset.yaml
+++ b/incubator/monochart/templates/statefulset.yaml
@@ -86,6 +86,12 @@ spec:
 {{- end }}
       volumes:
 {{ include "monochart.files.volumes" . | indent 6 }}
+{{- if not .Values.statefulset.persistence.useVolumeClaimTemplates }}
+      - name: {{ (include "common.fullname" . ) }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.statefulset.persistence.existingClaim | default (include "common.fullname" . ) }}
+{{- end }}
+{{- if .Values.statefulset.persistence.useVolumeClaimTemplates }}
   volumeClaimTemplates:
   - metadata:
       name: {{ include "common.fullname" . }}
@@ -109,6 +115,7 @@ spec:
       storageClassName: ""
 {{- else }}
       storageClassName: {{ .Values.statefulset.persistence.storageClass | quote }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/incubator/monochart/templates/statefulset.yaml
+++ b/incubator/monochart/templates/statefulset.yaml
@@ -111,9 +111,5 @@ spec:
       storageClassName: {{ .Values.statefulset.persistence.storageClass | quote }}
 {{- end }}
 {{- end }}
-{{- with .Values.statefulset.persistence.selector }}
-      selector:
-{{ toYaml . | indent 8 }}
-{{- end }}
 {{- end -}}
 {{- end -}}

--- a/incubator/monochart/templates/statefulset.yaml
+++ b/incubator/monochart/templates/statefulset.yaml
@@ -61,8 +61,10 @@ spec:
           protocol: {{ default "TCP" $port.protocol  }}
 {{- end }}
         volumeMounts:
+        {{- if .Values.persistence.enabled }}
         - mountPath: {{ .Values.persistence.mountPath | quote }}
-          name: storage
+          name: {{ .Values.persistence.storageName | default (include "common.fullname" .) }}
+        {{- end }}
 {{ include "monochart.files.volumeMounts" . | indent 8 }}
 {{- with .Values.probes }}
 {{ toYaml . | indent 8 }}
@@ -81,13 +83,18 @@ spec:
       {{- end }}
 {{- end }}
       volumes:
-      - name: storage
-      {{- if .Values.persistence.enabled }}
-        persistentVolumeClaim:
-          claimName: {{ .Values.persistence.existingClaim | default (include "common.fullname" .) }}
-      {{- else }}
-        emptyDir: {}
-      {{- end }}
 {{ include "monochart.files.volumes" . | indent 6 }}
+  {{- if .Values.persistence.enabled }}
+  volumeClaimTemplates:
+  - metadata:
+      name: {{ .Values.persistence.storageName | default (include "common.fullname" .) }}
+    spec:
+      accessModes:
+        - {{ .Values.persistence.accessMode }}
+      resources:
+        requests:
+          storage: {{ .Values.persistence.size }}
+      storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
 {{- end -}}
 {{- end -}}

--- a/incubator/monochart/templates/statefulset.yaml
+++ b/incubator/monochart/templates/statefulset.yaml
@@ -66,7 +66,7 @@ spec:
 {{- end }}
         volumeMounts:
         - mountPath: {{ .Values.statefulset.persistence.mountPath | quote }}
-          name: {{ .Values.statefulset.persistence.storageName }}
+          name: {{ include "common.fullname" . }}
 {{ include "monochart.files.volumeMounts" . | indent 8 }}
 {{- with .Values.probes }}
 {{ toYaml . | indent 8 }}

--- a/incubator/monochart/templates/statefulset.yaml
+++ b/incubator/monochart/templates/statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
 {{ include "common.labels.standard" . | indent 4 }}
 {{- with .Values.statefulset.labels }}
-{{ toYaml .| indent 4 }}
+{{ toYaml . | indent 4 }}
 {{- end }}
 spec:
   selector:
@@ -37,7 +37,7 @@ spec:
         release: {{ .Release.Name | quote }}
         serve: "true"
 {{- with .Values.statefulset.pod.labels }}
-{{ toYaml .| indent 4 }}
+{{ toYaml . | indent 4 }}
 {{- end }}
     spec:
       terminationGracePeriodSeconds: 0
@@ -46,10 +46,14 @@ spec:
         image: {{ required "image.repository is required!" .Values.image.repository }}:{{ required "image.tag is required!" .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
 {{ include "monochart.env" . | indent 8 }}
-        {{- if .Values.statefulset.pod.command }}
-        command: {{ toYaml .Values.statefulset.pod.command }}
-        {{- end }}
-        args: {{ toYaml .Values.statefulset.pod.args }}
+{{- with .Values.statefulset.pod.command }}
+        command:
+{{ toYaml . | indent 10 }}
+{{- end }}
+{{- with .Values.statefulset.pod.args }}
+        args:
+{{ toYaml . | indent 10 }}
+{{- end }}
 {{- with .Values.statefulset.pod.securityContext }}
         securityContext:
 {{ toYaml . | indent 10 }}
@@ -61,10 +65,8 @@ spec:
           protocol: {{ default "TCP" $port.protocol  }}
 {{- end }}
         volumeMounts:
-        {{- if .Values.persistence.enabled }}
-        - mountPath: {{ .Values.persistence.mountPath | quote }}
-          name: {{ .Values.persistence.storageName | default (include "common.fullname" .) }}
-        {{- end }}
+        - mountPath: {{ .Values.statefulset.persistence.mountPath | quote }}
+          name: {{ .Values.statefulset.persistence.storageName }}
 {{ include "monochart.files.volumeMounts" . | indent 8 }}
 {{- with .Values.probes }}
 {{ toYaml . | indent 8 }}
@@ -84,17 +86,34 @@ spec:
 {{- end }}
       volumes:
 {{ include "monochart.files.volumes" . | indent 6 }}
-  {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
   - metadata:
-      name: {{ .Values.persistence.storageName | default (include "common.fullname" .) }}
+      name: {{ .Values.statefulset.persistence.storageName }}
+{{- with .Values.statefulset.persistence.annotations }}
+      annotations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+      labels:
+{{ include "common.labels.standard" . | indent 8 }}
+{{- with .Values.statefulset.persistence.labels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
     spec:
       accessModes:
-        - {{ .Values.persistence.accessMode }}
+        - {{ .Values.statefulset.persistence.accessMode | quote }}
       resources:
         requests:
-          storage: {{ .Values.persistence.size }}
-      storageClassName: {{ .Values.persistence.storageClass }}
-  {{- end }}
+          storage: {{ .Values.statefulset.persistence.size | quote }}
+{{- if .Values.statefulset.persistence.storageClass }}
+{{- if (eq "-" .Values.statefulset.persistence.storageClass) }}
+      storageClassName: ""
+{{- else }}
+      storageClassName: {{ .Values.statefulset.persistence.storageClass | quote }}
+{{- end }}
+{{- end }}
+{{- with .Values.statefulset.persistence.selector }}
+      selector:
+{{ toYaml . | indent 8 }}
+{{- end }}
 {{- end -}}
 {{- end -}}

--- a/incubator/monochart/templates/statefulset.yaml
+++ b/incubator/monochart/templates/statefulset.yaml
@@ -19,7 +19,7 @@ spec:
       app: {{ include "common.name" . }}
       release: {{ .Release.Name }}
   serviceName: {{ include "common.fullname" . }}
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
 {{- with .Values.statefulset.strategy }}
   updateStrategy:
 {{ toYaml . | indent 4 }}

--- a/incubator/monochart/templates/statefulset.yaml
+++ b/incubator/monochart/templates/statefulset.yaml
@@ -88,7 +88,7 @@ spec:
 {{ include "monochart.files.volumes" . | indent 6 }}
   volumeClaimTemplates:
   - metadata:
-      name: {{ .Values.statefulset.persistence.storageName }}
+      name: {{ include "common.fullname" . }}
 {{- with .Values.statefulset.persistence.annotations }}
       annotations:
 {{ toYaml . | indent 8 }}

--- a/incubator/monochart/values.example.yaml
+++ b/incubator/monochart/values.example.yaml
@@ -53,7 +53,7 @@ deployment:
   enabled: true
   ## Pods replace strategy
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
-  # strategy: {}    
+  # strategy: {}
   revisionHistoryLimit: 10
   annotations:
     nginx.version: 1.15.3
@@ -61,6 +61,7 @@ deployment:
     component: nginx
   pod:
     annotations: {}
-    ## Read more about kube2iam to provide access to s3 https://github.com/jtblin/kube2iam
+    ## https://github.com/uswitch/kiam
+    ## https://github.com/jtblin/kube2iam
     #  iam.amazonaws.com/role: role-arn
     labels: {}

--- a/incubator/monochart/values.yaml
+++ b/incubator/monochart/values.yaml
@@ -95,9 +95,11 @@ statefulset:
     # args:
   ## Configure volumeClaimTemplate block
   persistence:
+    useVolumeClaimTemplates: true
     accessMode: ReadWriteOnce
     size: 8Gi
     mountPath: /data
+    # storageClass: gp2
   #   annotations:
   #     name: value
   #   labels:
@@ -318,8 +320,8 @@ persistence:
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning
   ## If undefined (the default) or set to null, no storageClassName spec is
-  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-  ##   GKE, AWS & OpenStack)
+  ## set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ## GKE, AWS & OpenStack)
   ##
   # storageClass: "-"
 

--- a/incubator/monochart/values.yaml
+++ b/incubator/monochart/values.yaml
@@ -68,7 +68,8 @@ deployment:
   pod:
     # securityContext: {}
     annotations: {}
-    ## Read more about kube2iam to provide access to s3 https://github.com/jtblin/kube2iam
+    ## https://github.com/uswitch/kiam
+    ## https://github.com/jtblin/kube2iam
     #  iam.amazonaws.com/role: role-arn
     labels: {}
     # command:
@@ -87,7 +88,8 @@ statefulset:
   pod:
     # securityContext: {}
     annotations: {}
-    ## Read more about kube2iam to provide access to s3 https://github.com/jtblin/kube2iam
+    ## https://github.com/uswitch/kiam
+    ## https://github.com/jtblin/kube2iam
     #  iam.amazonaws.com/role: role-arn
     labels: {}
     # command:
@@ -106,7 +108,8 @@ daemonset:
   pod:
     # securityContext: {}
     annotations: {}
-    ## Read more about kube2iam to provide access to s3 https://github.com/jtblin/kube2iam
+    ## https://github.com/uswitch/kiam
+    ## https://github.com/jtblin/kube2iam
     #  iam.amazonaws.com/role: role-arn
     labels: {}
     # command:
@@ -123,7 +126,8 @@ job:
     pod:
       # securityContext: {}
       annotations: {}
-      ## Read more about kube2iam to provide access to s3 https://github.com/jtblin/kube2iam
+      ## https://github.com/uswitch/kiam
+      ## https://github.com/jtblin/kube2iam
       #  iam.amazonaws.com/role: role-arn
       labels: {}
       # command:
@@ -145,7 +149,8 @@ cronjob:
     pod:
       # securityContext: {}
       annotations: {}
-      ## Read more about kube2iam to provide access to s3 https://github.com/jtblin/kube2iam
+      ## https://github.com/uswitch/kiam
+      ## https://github.com/jtblin/kube2iam
       #  iam.amazonaws.com/role: role-arn
       labels: {}
       # command:
@@ -287,6 +292,7 @@ resources:
 
 persistence:
   enabled: false
+  storageName: storage
   mountPath: /data
   accessMode: ReadWriteOnce
   size: 8Gi

--- a/incubator/monochart/values.yaml
+++ b/incubator/monochart/values.yaml
@@ -88,12 +88,20 @@ statefulset:
   pod:
     # securityContext: {}
     annotations: {}
-    ## https://github.com/uswitch/kiam
-    ## https://github.com/jtblin/kube2iam
+    ## Read more about kube2iam to provide access to s3 https://github.com/jtblin/kube2iam
     #  iam.amazonaws.com/role: role-arn
     labels: {}
     # command:
-    args: []
+    # args:
+  ## Configure volumeClaimTemplate block
+  persistence:
+    accessMode: ReadWriteOnce
+    size: 8Gi
+    mountPath: /data
+  #   annotations:
+  #     name: value
+  #   labels:
+  #     name: value
 
 daemonset:
   enabled: false


### PR DESCRIPTION
## what
* [monochart] Add `volumeClaimTemplates` to `StatefulSet`

## why
* When you have an app which requires persistence, you should create a `StatefulSet` instead of `Deployment`. There are many benefits. You will not have to create a PVCs in advance, and you will be able to scale it easily. With the `StatefulSet`, you can define a `volumeClaimTemplates` so that a new PVC is created for each replica automatically. Also, you will end up with only one file which defines your app and also persistent volumes

## references
* https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
* https://akomljen.com/kubernetes-persistent-volumes-with-deployment-and-statefulset/
* https://medium.com/@joatmon08/kubernetes-statefulset-recovery-from-aws-snapshots-8a6159cda6f1


