### PR TITLE
[teleport-ent-proxy] Enable private cluster

### DIFF
--- a/incubator/teleport-ent-proxy/Chart.yaml
+++ b/incubator/teleport-ent-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "3.1.8"
 description: A Helm chart for Teleport Proxy service
 name: teleport-ent-proxy
-version: 0.1.0
+version: 0.2.0

--- a/incubator/teleport-ent-proxy/templates/NOTES.txt
+++ b/incubator/teleport-ent-proxy/templates/NOTES.txt
@@ -6,8 +6,8 @@
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get svc -w {{ include "teleport-proxy.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "teleport-proxy.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
+  export SERVICE_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "teleport-proxy.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+  echo curl --insecure https://$SERVICE_HOST:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "teleport-proxy.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"

--- a/incubator/teleport-ent-proxy/templates/certificate.yaml
+++ b/incubator/teleport-ent-proxy/templates/certificate.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.tls.enabled }}
+{{- if and .Values.tls.enabled (not .Values.tls.useSelfSignedCert) }}
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:

--- a/incubator/teleport-ent-proxy/templates/deployment.yaml
+++ b/incubator/teleport-ent-proxy/templates/deployment.yaml
@@ -88,7 +88,7 @@ spec:
             - mountPath: /etc/teleport
               name: config
               readOnly: true
-          {{- if .Values.tls.enabled }}
+          {{- if and .Values.tls.enabled (not .Values.tls.useSelfSignedCert) }}
             - mountPath: /etc/teleport/certs
               name: certificates
               readOnly: true
@@ -113,7 +113,7 @@ spec:
         - name: config
           secret:
             secretName: "{{ include "teleport-proxy.fullname" . }}"
-        {{- if .Values.tls.enabled }}
+        {{- if and .Values.tls.enabled (not .Values.tls.useSelfSignedCert) }}
         - name: certificates
           secret:
             secretName: "{{ include "teleport-proxy.tlsSecret" . }}"

--- a/incubator/teleport-ent-proxy/templates/service.yaml
+++ b/incubator/teleport-ent-proxy/templates/service.yaml
@@ -13,8 +13,10 @@ metadata:
 {{ toYaml .Values.service.annotations | indent 4 }}
 {{- end }}
 spec:
-  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | default "Cluster" }}
   type: {{ .Values.service.type }}
+{{- if or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort") }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | default "Cluster" }}
+{{- end }}
   ports:
     - port: 443
       targetPort: 3080

--- a/incubator/teleport-ent-proxy/values.yaml
+++ b/incubator/teleport-ent-proxy/values.yaml
@@ -16,7 +16,8 @@ config:
 tls:
   ## Enable mounting of TLS certificates from a secret
   ## If disabled, teleport proxy will generate self signed certs on launch
-  enabled: yes
+  enabled: true
+  useSelfSignedCert: false
 
   ## Ingress to perform tls certification verifications through
   ## See http://docs.cert-manager.io/en/latest/tutorials/acme/http-validation.html


### PR DESCRIPTION
## what
Enable private cluster which delegates access to other Trusted Teleport Cluster

## why
Isolate cluster for better security (no direct access from internet)