### PR TITLE
[teleport-ent-proxy] Satisfy RBAC requirements for Teleport v3.2

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.idea
+*.iml
+.build-harness
+build-harness
+tmp/**

--- a/incubator/teleport-ent-proxy/Chart.yaml
+++ b/incubator/teleport-ent-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "3.1.8"
+appVersion: "3.2.2"
 description: A Helm chart for Teleport Proxy service
 name: teleport-ent-proxy
-version: 0.2.0
+version: 0.3.0

--- a/incubator/teleport-ent-proxy/templates/_helpers.tpl
+++ b/incubator/teleport-ent-proxy/templates/_helpers.tpl
@@ -41,3 +41,13 @@ Create chart name and version as used by the chart label.
 {{- define "teleport-proxy.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "teleport-proxy.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "teleport-proxy.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/incubator/teleport-ent-proxy/templates/clusterrole.yaml
+++ b/incubator/teleport-ent-proxy/templates/clusterrole.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "teleport-proxy.fullname" . }}
+  labels:
+    app: {{ template "teleport-proxy.name" . }}
+    chart: {{ template "teleport-proxy.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - users
+  - groups
+  - serviceaccounts
+  verbs:
+  - impersonate
+{{- end -}}

--- a/incubator/teleport-ent-proxy/templates/clusterrolebinding.yaml
+++ b/incubator/teleport-ent-proxy/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "teleport-proxy.fullname" . }}
+  labels:
+    app: {{ template "teleport-proxy.name" . }}
+    chart: {{ template "teleport-proxy.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "teleport-proxy.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "teleport-proxy.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/incubator/teleport-ent-proxy/templates/deployment.yaml
+++ b/incubator/teleport-ent-proxy/templates/deployment.yaml
@@ -27,6 +27,9 @@ spec:
         fsGroup: {{ .Values.securityContext.fsGroup }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
       {{- end }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ template "teleport-proxy.serviceAccountName" . }}
+      {{- end }}
       containers:
         - name: {{ include "teleport-proxy.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/incubator/teleport-ent-proxy/templates/serviceaccount.yaml
+++ b/incubator/teleport-ent-proxy/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "teleport-proxy.serviceAccountName" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "teleport-proxy.name" . }}
+    app.kubernetes.io/component: "{{ .Values.name }}"
+    helm.sh/chart: {{ include "teleport-proxy.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/incubator/teleport-ent-proxy/values.yaml
+++ b/incubator/teleport-ent-proxy/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: quay.io/gravitational/teleport-ent
-  pullPolicy: "Always"
+  pullPolicy: "IfNotPresent"
 
 name: proxy
 nameOverride: teleport-proxy
@@ -12,6 +12,20 @@ replicaCount: 2
 config:
   ## See https://gravitational.com/teleport/docs/admin-guide/#configuration-file
   teleport.yaml: |-
+
+## set create: true to create kubernetes roles and bindings.
+## Required to enable Kubernetes integration starting with Teleport version 3.2.0
+rbac:
+  create: true
+
+## Create a service account
+## Required to enable Kubernetes integration starting with Teleport version 3.2.0
+serviceAccount:
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
 
 tls:
   ## Enable mounting of TLS certificates from a secret


### PR DESCRIPTION
## what
[teleport-ent-proxy] Satisfy RBAC requirements for Teleport v3.2
## why
[Teleport v3.2](https://github.com/gravitational/teleport/releases/tag/v3.2.0) switched from using the CSR API on the auth server to using the impersonation API on the proxy server in order to grant access to Kubernetes resources. This requires new RBAC permissions for the proxy server.
## references
https://github.com/gravitational/teleport/commit/aefe8860c108ab91a3836832e5013274a3353620#diff-98bdb67a508f59c119f00a0aaaeaef13
https://github.com/gravitational/teleport/blob/aefe8860c108ab91a3836832e5013274a3353620/examples/chart/teleport/templates/clusterrole.yaml
