### PR TITLE
[fluentd] Simplified chart for AWS elasticsearch

### DIFF
--- a/incubator/fluentd-kubernetes-aws/.helmignore
+++ b/incubator/fluentd-kubernetes-aws/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/incubator/fluentd-kubernetes-aws/Chart.yaml
+++ b/incubator/fluentd-kubernetes-aws/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+description: Collect Kubernetes logs with Fluentd and forward to AWS-hosted Elasticsearch.
+icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
+name: fluentd-kubernetes-aws
+version: 0.1.0
+appVersion: 1.3.3
+home: https://www.fluentd.org/
+sources:
+- https://hub.docker.com/r/fluent/fluentd-kubernetes-daemonset
+- https://github.com/fluent/fluentd-kubernetes-daemonset
+maintainers:
+- name: cloudposse
+  email: hello@cloudposse.com

--- a/incubator/fluentd-kubernetes-aws/Chart.yaml
+++ b/incubator/fluentd-kubernetes-aws/Chart.yaml
@@ -3,7 +3,7 @@ description: Collect Kubernetes logs with Fluentd and forward to AWS-hosted Elas
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
 name: fluentd-kubernetes-aws
 version: 0.1.0
-appVersion: 1.3.3
+appVersion: 1.4.2
 home: https://www.fluentd.org/
 sources:
 - https://hub.docker.com/r/fluent/fluentd-kubernetes-daemonset

--- a/incubator/fluentd-kubernetes-aws/README.md
+++ b/incubator/fluentd-kubernetes-aws/README.md
@@ -1,0 +1,49 @@
+# Fluentd AWS
+
+Helm chart to run [fluentd](https://www.fluentd.org/) on kubernetes and connect to
+an AWS Elasticsearch domain protected by IAM.
+
+## Use cases
+
+This specialized chart covers the case where:
+- your Kubernetes cluster has RBAC enabled
+- you are using [`kiam`](https://github.com/uswitch/kiam) to assign IAM roles to pods
+- you have an [AWS Elasticsearch](https://aws.amazon.com/elasticsearch-service/)
+- you have created an IAM role that has access to Elasticsearch
+- you want Fluentd to collect logs from your Kubernetes cluster and forward them to Elasticsearch.
+
+## Credit
+
+This chart is based on [fluentd-daemonset-elasticsearch-rbac.yaml](https://github.com/fluent/fluentd-kubernetes-daemonset/blob/8c76f51/fluentd-daemonset-elasticsearch-rbac.yaml)
+
+#### Quick start
+```
+helm install incubator/fluentd-kubernetes-aws \
+    --set elasticsearch.endpoint=<elasticsearch_domain_endpoint> \
+    --set role=<IAM role>
+```
+
+#### Full config
+
+This chart installs the [fluentd-kubernetes-daemonset](https://github.com/fluent/fluentd-kubernetes-daemonset)
+that is specialied to forward logs to Elasticsearch. That installation is entirely configured
+with environment variables which are not specifcially documented, but are well named
+and can be found by inspecting the templates at https://github.com/fluent/fluentd-kubernetes-daemonset/tree/8c76f51/templates
+
+Those values can be set using `env.NAME=value`
+
+Example `values.yaml` file:
+```yaml
+image: 
+  repository: fluent/fluentd-kubernetes-daemonset
+  tag: v1.3.3-debian-elasticsearch-1.8
+
+role: elasticsearch-user
+
+elasticsearch:
+  endpoint: my-elasticsearch-jivhavxbcd5dvcbjzrac7j42rm.us-west-2.es.amazonaws.com
+  
+env:
+  FLUENT_ELASTICSEARCH_RELOAD_CONNECTIONS: false
+  FLUENT_ELASTICSEARCH_BUFFER_FLUSH_INTERVAL: 10s
+```

--- a/incubator/fluentd-kubernetes-aws/templates/NOTES.txt
+++ b/incubator/fluentd-kubernetes-aws/templates/NOTES.txt
@@ -1,0 +1,6 @@
+To verify that Fluentd  has started, run:
+
+  kubectl --namespace={{ .Release.Namespace }} get all -l "app={{ template "fluentd_kubernetes.name" . }},release={{ .Release.Name }}"
+
+THIS APPLICATION CAPTURES ALL CONSOLE OUTPUT AND FORWARDS IT TO configured backend storage. Anything that might be identifying,
+including things like IP addresses, container images, and object names will NOT be anonymized.

--- a/incubator/fluentd-kubernetes-aws/templates/_helpers.tpl
+++ b/incubator/fluentd-kubernetes-aws/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "fluentd_kubernetes.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "fluentd_kubernetes.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "fluentd_kubernetes.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/fluentd-kubernetes-aws/templates/clusterrole.yaml
+++ b/incubator/fluentd-kubernetes-aws/templates/clusterrole.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "fluentd_kubernetes.fullname" . }}
+  labels:
+    app: {{ template "fluentd_kubernetes.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch

--- a/incubator/fluentd-kubernetes-aws/templates/clusterrolebinding.yaml
+++ b/incubator/fluentd-kubernetes-aws/templates/clusterrolebinding.yaml
@@ -1,0 +1,17 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "fluentd_kubernetes.fullname" . }}
+  labels:
+    app: {{ template "fluentd_kubernetes.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "fluentd_kubernetes.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "fluentd_kubernetes.fullname" . }}
+    namespace: {{ .Release.Namespace }}

--- a/incubator/fluentd-kubernetes-aws/templates/daemonset.yaml
+++ b/incubator/fluentd-kubernetes-aws/templates/daemonset.yaml
@@ -1,6 +1,5 @@
 apiVersion: apps/v1
-{{/*kind: DaemonSet*/}}
-kind: Deployment
+kind: DaemonSet
 metadata:
   name: {{ template "fluentd_kubernetes.fullname" . }}
   labels:
@@ -25,32 +24,35 @@ spec:
         kubernetes.io/cluster-service: "true"
         app: {{ template "fluentd_kubernetes.name" . }}
         release: {{ .Release.Name }}
+      {{- if .Values.role }}
       annotations:
         iam.amazonaws.com/role: {{ .Values.role }}
+      {{- end }}
     spec:
       serviceAccountName: {{ template "fluentd_kubernetes.fullname" . }}
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchFields:
-                  - key: metadata.name
-                    operator: In
-                    values:
-                      - ip-10-105-15-232.eu-west-2.compute.internal
       containers:
       - name: fluentd
         image: {{ .Values.image.repository}}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
         env:
+        {{- if .Values.role }}
           - name: FLUENT_ELASTICSEARCH_HOST
             value: "localhost"
           - name: FLUENT_ELASTICSEARCH_PORT
             value: "9200"
           - name: FLUENT_ELASTICSEARCH_SCHEME
             value: "http"
+        {{- else }}
+          - name: FLUENT_ELASTICSEARCH_HOST
+            value: "{{ .Values.elasticsearch.endpoint }}"
+          - name: FLUENT_ELASTICSEARCH_PORT
+            value: "443"
+          - name: FLUENT_ELASTICSEARCH_SCHEME
+            value: "https"
+        {{- end }}
           {{- range $name, $value := .Values.env }}
           {{- if (not (empty $value)) and (not (eq $name "FLUENT_ELASTICSEARCH_HOST" "FLUENT_ELASTICSEARCH_SCHEME")) }}
           - name: {{ $name | quote }}
@@ -65,8 +67,16 @@ spec:
         - name: varlibdockercontainers
           mountPath: /var/lib/docker/containers
           readOnly: true
-
+      {{- if .Values.role }}
       - name: signing-proxy
+        # This image, abutaha/aws-es-proxy:0.9, still has issues, but the Fluentd plugin seems not to be affected by them.
+        # Still, the image should be updated when possible, but once we find a good image it should not need to be
+        # updated further until AWS changes their signing algorithm.
+        # https://github.com/abutaha/aws-es-proxy/issues/27
+        # https://github.com/abutaha/aws-es-proxy/issues/29
+        # https://github.com/abutaha/aws-es-proxy/issues/35
+        # An alternative is mozilla/aws-signing-proxy but as of version 1.0.3 it did not work
+        # https://github.com/mozilla-services/aws-signing-proxy/issues/9
         image: abutaha/aws-es-proxy:0.9
         imagePullPolicy: IfNotPresent
         args:
@@ -83,7 +93,7 @@ spec:
           requests:
            cpu: 5m
            memory: 10Mi
-
+      {{- end }}
       terminationGracePeriodSeconds: 30
       volumes:
         - name: varlog

--- a/incubator/fluentd-kubernetes-aws/templates/daemonset.yaml
+++ b/incubator/fluentd-kubernetes-aws/templates/daemonset.yaml
@@ -1,0 +1,94 @@
+apiVersion: apps/v1
+{{/*kind: DaemonSet*/}}
+kind: Deployment
+metadata:
+  name: {{ template "fluentd_kubernetes.fullname" . }}
+  labels:
+    k8s-app: fluentd-logging
+    version: v1
+    kubernetes.io/cluster-service: "true"
+    app: {{ template "fluentd_kubernetes.name" . }}
+    chart: {{ template "fluentd_kubernetes.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      k8s-app: fluentd-logging
+      app: {{ template "fluentd_kubernetes.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        k8s-app: fluentd-logging
+        version: v1
+        kubernetes.io/cluster-service: "true"
+        app: {{ template "fluentd_kubernetes.name" . }}
+        release: {{ .Release.Name }}
+      annotations:
+        iam.amazonaws.com/role: {{ .Values.role }}
+    spec:
+      serviceAccountName: {{ template "fluentd_kubernetes.fullname" . }}
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchFields:
+                  - key: metadata.name
+                    operator: In
+                    values:
+                      - ip-10-105-15-232.eu-west-2.compute.internal
+      containers:
+      - name: fluentd
+        image: {{ .Values.image.repository}}:{{ .Values.image.tag }}
+        env:
+          - name: FLUENT_ELASTICSEARCH_HOST
+            value: "localhost"
+          - name: FLUENT_ELASTICSEARCH_PORT
+            value: "9200"
+          - name: FLUENT_ELASTICSEARCH_SCHEME
+            value: "http"
+          {{- range $name, $value := .Values.env }}
+          {{- if (not (empty $value)) and (not (eq $name "FLUENT_ELASTICSEARCH_HOST" "FLUENT_ELASTICSEARCH_SCHEME")) }}
+          - name: {{ $name | quote }}
+            value: {{ $value | quote }}
+          {{- end }}
+          {{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+
+      - name: signing-proxy
+        image: abutaha/aws-es-proxy:0.9
+        imagePullPolicy: IfNotPresent
+        args:
+        - "-endpoint"
+        - "https://{{ .Values.elasticsearch.endpoint }}"
+        - "-listen"
+        - "127.0.0.1:9200"
+        {{- if .Values.debug.signer }}
+        - "-pretty"
+        - "-verbose"
+        - "-log-to-file"
+        {{- end }}
+        resources:
+          requests:
+           cpu: 5m
+           memory: 10Mi
+
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers

--- a/incubator/fluentd-kubernetes-aws/templates/prometheusrule.yaml
+++ b/incubator/fluentd-kubernetes-aws/templates/prometheusrule.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.prometheus.createRule }}
+# Copied from https://github.com/kiwigrid/helm-charts/blob/416e9ef84ad865846d263e2fccdf0c32ed9fee81/charts/fluentd-elasticsearch/templates/prometheusrule.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name:  {{ template "fluentd_kubernetes.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "fluentd_kubernetes.name" . }}
+    helm.sh/chart: {{ include "fluentd_kubernetes.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.prometheus.labels }}
+{{- toYaml .Values.prometheus.labels | nindent 4 }}
+{{- end }}
+spec:
+  groups:
+  - name: fluentd
+    rules:
+    - alert: FluentdNodeDown
+      expr: up{job="{{ .Release.Name }}"} == 0
+      for: 10m
+      labels:
+        service: fluentd
+        severity: warning
+      annotations:
+        summary: fluentd cannot be scraped
+        description: Prometheus could not scrape {{ "{{ $labels.job }}" }} for more than 10 minutes
+
+    - alert: FluentdNodeDown
+      expr: up{job="{{ .Release.Name }}"} == 0
+      for: 30m
+      labels:
+        service: fluentd
+        severity: critical
+      annotations:
+        summary: fluentd cannot be scraped
+        description: Prometheus could not scrape {{ "{{ $labels.job }}" }} for more than 30 minutes
+
+    - alert: FluentdQueueLength
+      expr: rate(fluentd_status_buffer_queue_length[5m]) > 0.3
+      for: 1m
+      labels:
+        service: fluentd
+        severity: warning
+      annotations:
+        summary: fluentd node are failing
+        description: In the last 5 minutes, fluentd queues increased 30%. Current value is {{ "{{ $value }}" }}
+
+    - alert: FluentdQueueLength
+      expr: rate(fluentd_status_buffer_queue_length[5m]) > 0.5
+      for: 1m
+      labels:
+        service: fluentd
+        severity: critical
+      annotations:
+        summary: fluentd node are critical
+        description: In the last 5 minutes, fluentd queues increased 50%. Current value is {{ "{{ $value }}" }}
+
+    - alert: FluentdRecordsCountsHigh
+      expr: sum(rate(fluentd_record_counts{job="{{ .Release.Name }}"}[5m])) BY (instance) >  (3 * sum(rate(fluentd_record_counts{job="{{ .Release.Name }}"}[15m])) BY (instance))
+      for: 1m
+      labels:
+        service: fluentd
+        severity: critical
+      annotations:
+        summary: fluentd records count are critical
+        description: In the last 5m, records counts increased 3 times, comparing to the latest 15 min.
+
+{{- end }}

--- a/incubator/fluentd-kubernetes-aws/templates/service.yaml
+++ b/incubator/fluentd-kubernetes-aws/templates/service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.prometheus.createService }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fluentd_kubernetes.fullname" . }}-prometheus
+  labels:
+    app: {{ template "fluentd_kubernetes.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: prometheus
+      port: 9224
+      protocol: TCP
+      targetPort: {{ index .Values.env "FLUENTD_PROMETHEUS_PORT" | default "24231" }}
+  selector:
+    app: {{ template "fluentd_kubernetes.name" . }}
+    release: {{ .Release.Name }}
+{{- end }}

--- a/incubator/fluentd-kubernetes-aws/templates/service.yaml
+++ b/incubator/fluentd-kubernetes-aws/templates/service.yaml
@@ -4,10 +4,11 @@ kind: Service
 metadata:
   name: {{ template "fluentd_kubernetes.fullname" . }}-prometheus
   labels:
-    app: {{ template "fluentd_kubernetes.name" . }}
+    app: {{ template "fluentd_kubernetes.name" . }}-prometheus
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+
 spec:
   type: ClusterIP
   ports:

--- a/incubator/fluentd-kubernetes-aws/templates/serviceaccount.yaml
+++ b/incubator/fluentd-kubernetes-aws/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "fluentd_kubernetes.fullname" . }}
+  labels:
+    app: {{ template "fluentd_kubernetes.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}

--- a/incubator/fluentd-kubernetes-aws/templates/servicemonitor.yaml
+++ b/incubator/fluentd-kubernetes-aws/templates/servicemonitor.yaml
@@ -9,7 +9,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 {{- if .Values.prometheus.labels }}
-{{- toYaml .Values.prometheus.labels | indent 4 }}
+{{ toYaml .Values.prometheus.labels | indent 4 }}
 {{- end }}
 
 spec:

--- a/incubator/fluentd-kubernetes-aws/templates/servicemonitor.yaml
+++ b/incubator/fluentd-kubernetes-aws/templates/servicemonitor.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.prometheus.createServiceMonitor }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "fluentd_kubernetes.fullname" . }}
+  labels:
+    app: {{ template "fluentd_kubernetes.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.prometheus.labels }}
+{{- toYaml .Values.prometheus.labels | indent 4 }}
+{{- end }}
+
+spec:
+  endpoints:
+  - path: /metrics
+    port: prometheus
+  selector:
+    namespaceSelector:
+      any: true
+    matchLabels:
+      app: {{ template "fluentd_kubernetes.name" . }}-prometheus
+      release: {{ .Release.Name }}
+{{- end }}

--- a/incubator/fluentd-kubernetes-aws/values.yaml
+++ b/incubator/fluentd-kubernetes-aws/values.yaml
@@ -1,0 +1,41 @@
+# Default values for fluentd-kubernetes-aws.
+
+image:
+  repository: fluent/fluentd-kubernetes-daemonset
+  tag: v1.3.3-debian-elasticsearch-1.8
+
+role: elasticsearch-user
+
+elasticsearch:
+  endpoint: my-elasticsearch-jivhavxbcd5dvcbjzrac7j42rm.us-east-1.es.amazonaws.com
+  region: us-east-1
+
+prometheus:
+  createService: true
+  createServiceMonitor: true
+  createRule: true
+  labels:
+    app: prometheus-operator
+    release: prometheus-operator
+
+env:
+  # set environment variables in the form name: value
+  FLUENTD_PROMETHEUS_PORT: 24231
+  FLUENT_ELASTICSEARCH_BUFFER_CHUNK_LIMIT_SIZE: 4M
+  FLUENT_ELASTICSEARCH_BUFFER_QUEUE_LIMIT_LENGTH: 64
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 500m
+  #  memory: 200Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 200Mi
+
+debug:
+  fluentd: false
+  signer: false

--- a/incubator/fluentd-kubernetes-aws/values.yaml
+++ b/incubator/fluentd-kubernetes-aws/values.yaml
@@ -2,12 +2,12 @@
 
 image:
   repository: fluent/fluentd-kubernetes-daemonset
-  tag: v1.3.3-debian-elasticsearch-1.8
+  tag: v1.4.2-debian-elasticsearch-1.1
 
 role: elasticsearch-user
 
 elasticsearch:
-  endpoint: my-elasticsearch-jivhavxbcd5dvcbjzrac7j42rm.us-east-1.es.amazonaws.com
+  endpoint: my-elasticsearch-jivhavxbcd5.us-east-1.es.amazonaws.com
   region: us-east-1
 
 prometheus:


### PR DESCRIPTION
## what
A simplified chart for Fluentd with AWS Elasticsearch
## why
- Add support for IAM role restrictions by signing requests to AWS Elasticsearch
- Add support for monitoring Fluentd with Prometheus via ServiceMonitor and PrometheusRules resources
- Add RBAC roles and bindings