### PR TITLE
[github-authorized-keys] support passing integratessh as value

### DIFF
--- a/incubator/github-authorized-keys/templates/daemonset.yaml
+++ b/incubator/github-authorized-keys/templates/daemonset.yaml
@@ -137,8 +137,13 @@ spec:
 {{end}}
         - name: SYNC_USERS_ROOT
           value: /host
+{{if .Values.integrateSSH}}
         - name: INTEGRATE_SSH
-          value: "true"
+          valueFrom:
+            secretKeyRef:
+              name: github-authorized-keys
+              key: integrateSSH
+{{end}}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:

--- a/incubator/github-authorized-keys/templates/secrets.yaml
+++ b/incubator/github-authorized-keys/templates/secrets.yaml
@@ -59,3 +59,7 @@ data:
 {{if .Values.tplSSHRestart}}
   tplSSHRestart: {{ trim .Values.tplSSHRestart | b64enc | quote }}
 {{end}}
+
+{{if .Values.integrateSSH}}
+  integrateSSH: {{ trim .Values.integrateSSH | b64enc | quote }}
+{{end}}

--- a/incubator/github-authorized-keys/values.yaml
+++ b/incubator/github-authorized-keys/values.yaml
@@ -79,6 +79,10 @@ etcdClusterSize: 3
 ##
 etcdTTL: "86400"
 
+## Specify whether or not to automatically configure ssh
+##
+integrateSSH: "true"
+
 ## Template of create user command
 ##
 ## Available placeholders


### PR DESCRIPTION
Modifies the github-authorized-keys chart to allow passing the `INTEGRATE_SSH` environment variable to the tool, instead of hardcoding as `"true"`