### PR TITLE
[teleport-ent-auth] Increase failure timeout length

### DIFF
--- a/incubator/teleport-ent-auth/Chart.yaml
+++ b/incubator/teleport-ent-auth/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "3.1.8"
 description: A Helm chart for Teleport Auth service
 name: teleport-ent-auth
-version: 0.1.0
+version: 0.1.1

--- a/incubator/teleport-ent-auth/templates/deployment.yaml
+++ b/incubator/teleport-ent-auth/templates/deployment.yaml
@@ -67,14 +67,16 @@ spec:
           httpGet:
             path: /healthz
             port: {{ .Values.diagnostics.port | default 3000 }}
-          initialDelaySeconds: 30
+          initialDelaySeconds: 70
           timeoutSeconds: 3
+          failureThreshold: 3
         readinessProbe:
           httpGet:
             path: /readyz
             port: {{ .Values.diagnostics.port | default 3000 }}
           initialDelaySeconds: 30
           timeoutSeconds: 3
+          failureThreshold: 5
         {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}

--- a/incubator/teleport-ent-auth/values.yaml
+++ b/incubator/teleport-ent-auth/values.yaml
@@ -57,7 +57,6 @@ bootstrap:
   ## Script used to install resources when auth service is launched
   script: |-
     #!/bin/bash
-    set -e -o pipefail
     # Log script output to /var/log/
     exec >  >(tee -ia /var/log/teleport-bootstrap.log)
     exec 2> >(tee -ia /var/log/teleport-bootstrap.log >&2)


### PR DESCRIPTION
## what
1. Give longer time before failure is declared
1. Do not exit `bootstrap` script on failure

## why
1. Typically takes about 60 seconds to come up on systems we have seen
1. Script is expected to encounter errors while server is starting