### PR TITLE
ExternalName service type supported now

### DIFF
--- a/incubator/monochart/Chart.yaml
+++ b/incubator/monochart/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A declarative helm chart for deploying common types of services on Kubernetes
 name: monochart
-version: 0.13.0
-appVersion: 0.13.0
+version: 0.14.0
+appVersion: 0.14.0
 home: https://github.com/cloudposse/charts/tree/master/incubator/monochart
 icon: https://raw.githubusercontent.com/cloudposse/charts/master/incubator/monochart/logo.png
 maintainers:

--- a/incubator/monochart/templates/service.yaml
+++ b/incubator/monochart/templates/service.yaml
@@ -14,6 +14,9 @@ metadata:
 {{- end }}
 spec:
   type: {{ .Values.service.type }}
+{{- if eq .Values.service.type "ExternalName" }}
+  externalName: {{ .Values.service.externalName }}
+{{- else }}
   ports:
 {{- range $name, $port := .Values.service.ports }}
   - port: {{ $port.external }}
@@ -25,4 +28,5 @@ spec:
     app: {{ include "common.name" . }}
     release: {{ .Release.Name }}
     serve: "true"
+{{- end -}}
 {{- end -}}


### PR DESCRIPTION
## what
* `ExternalName` service type support

## why
* useful to create a gateway around SSO for external clients like SAAS