### PR TITLE
[nginx-default-backend] Add a PodDisruptionBudget

### DIFF
--- a/incubator/nginx-default-backend/Chart.yaml
+++ b/incubator/nginx-default-backend/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for nginx-default-backend to be used by nginx-ingress controller
 name: nginx-default-backend
-version: 0.3.0
+version: 0.4.0

--- a/incubator/nginx-default-backend/templates/deployment.yaml
+++ b/incubator/nginx-default-backend/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}

--- a/incubator/nginx-default-backend/templates/poddisruptionbudget.yaml
+++ b/incubator/nginx-default-backend/templates/poddisruptionbudget.yaml
@@ -1,0 +1,16 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    k8s-addon: ingress-nginx.addons.k8s.io
+    app: {{ template "fullname" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
+      k8s-addon: ingress-nginx.addons.k8s.io
+  maxUnavailable: {{ .Values.maxUnavailable }}

--- a/incubator/nginx-default-backend/values.yaml
+++ b/incubator/nginx-default-backend/values.yaml
@@ -2,6 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 replicaCount: 1
+maxUnavailable: 1
 image:
   repository: nginx
   tag: alpine


### PR DESCRIPTION
## what
[nginx-default-backend] Add a PodDisruptionBudget

## why
Enable [nginx-default-backend] pods to be moved around during cluster scaling, etc.