### PR TITLE
[teleport-ent-*] Add PodDisruptionBudgets to Teleport

### DIFF
--- a/incubator/teleport-ent-auth/Chart.yaml
+++ b/incubator/teleport-ent-auth/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "3.1.8"
+appVersion: "4.0.9"
 description: A Helm chart for Teleport Auth service
 name: teleport-ent-auth
-version: 0.1.1
+version: 0.2.0

--- a/incubator/teleport-ent-auth/templates/deployment.yaml
+++ b/incubator/teleport-ent-auth/templates/deployment.yaml
@@ -13,7 +13,8 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 99%
+      maxUnavailable: {{ default 0 .Values.maxUnavailable }}
+      maxSurge: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "teleport-auth.name" . }}

--- a/incubator/teleport-ent-auth/templates/poddisruptionbudget.yaml
+++ b/incubator/teleport-ent-auth/templates/poddisruptionbudget.yaml
@@ -1,0 +1,21 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "teleport-auth.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "teleport-auth.name" . }}
+    app.kubernetes.io/component: "{{ .Values.name }}"
+    helm.sh/chart: {{ include "teleport-auth.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "teleport-auth.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: "{{ .Values.name }}"
+  {{- if .Values.minAvailable }}
+  minAvailable: {{ .Values.minAvailable }}
+  {{- else }}
+  maxUnavailable: {{ default 0 .Values.maxUnavailable }}
+  {{- end }}

--- a/incubator/teleport-ent-auth/values.yaml
+++ b/incubator/teleport-ent-auth/values.yaml
@@ -8,7 +8,8 @@ nameOverride: teleport-auth
 
 ## Teleport service replicas
 ## See https://gravitational.com/teleport/docs/admin-guide/#auth-server-ha
-replicaCount: 1
+replicaCount: 2
+maxUnavailable: 50%
 
 rbac:
   create: true

--- a/incubator/teleport-ent-proxy/Chart.yaml
+++ b/incubator/teleport-ent-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "3.2.2"
+appVersion: "4.0.9"
 description: A Helm chart for Teleport Proxy service
 name: teleport-ent-proxy
-version: 0.3.0
+version: 0.4.0

--- a/incubator/teleport-ent-proxy/templates/deployment.yaml
+++ b/incubator/teleport-ent-proxy/templates/deployment.yaml
@@ -10,6 +10,11 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: {{ default 0 .Values.maxUnavailable }}
+      maxSurge: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "teleport-proxy.name" . }}
@@ -17,6 +22,10 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
+{{- with .Values.podAnnotations }}
+      annotations:
+{{ toYaml . | indent 8 }}
+{{- end }}
       labels:
         app.kubernetes.io/name: {{ include "teleport-proxy.name" . }}
         app.kubernetes.io/component: "{{ .Values.name }}"

--- a/incubator/teleport-ent-proxy/templates/poddisruptionbudget.yaml
+++ b/incubator/teleport-ent-proxy/templates/poddisruptionbudget.yaml
@@ -1,0 +1,21 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "teleport-proxy.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "teleport-proxy.name" . }}
+    app.kubernetes.io/component: "{{ .Values.name }}"
+    helm.sh/chart: {{ include "teleport-proxy.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "teleport-proxy.name" . }}
+      app.kubernetes.io/component: "{{ .Values.name }}"
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- if .Values.minAvailable }}
+  minAvailable: {{ .Values.minAvailable }}
+  {{- else }}
+  maxUnavailable: {{ default 0 .Values.maxUnavailable }}
+  {{- end }}

--- a/incubator/teleport-ent-proxy/values.yaml
+++ b/incubator/teleport-ent-proxy/values.yaml
@@ -6,6 +6,7 @@ name: proxy
 nameOverride: teleport-proxy
 
 replicaCount: 2
+maxUnavailable: 50%
 
 ## Configuration to be copied into Teleport container
 ## Each entry must be an inline file that will be written to /etc/teleport


### PR DESCRIPTION
## what
- [teleport-ent-auth] Add PodDisruptionBudget
- [teleport-ent-proyx] Add PodDisruptionBudget and configurable pod annotations

## why
- Better compatibility with cluster autoscaler