### PR TITLE
deployment affinity support added

### DIFF
--- a/incubator/monochart/Chart.yaml
+++ b/incubator/monochart/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A declarative helm chart for deploying common types of services on Kubernetes
 name: monochart
-version: 0.15.0
-appVersion: 0.15.0
+version: 0.16.0
+appVersion: 0.16.0
 home: https://github.com/cloudposse/charts/tree/master/incubator/monochart
 icon: https://raw.githubusercontent.com/cloudposse/charts/master/incubator/monochart/logo.png
 maintainers:

--- a/incubator/monochart/templates/_helpers.tpl
+++ b/incubator/monochart/templates/_helpers.tpl
@@ -99,3 +99,23 @@ VolumeMounts template block for deployable resources
 {{- end }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+The pod anti-affinity rule to prefer not to be scheduled onto a node if that node is already running a pod with same app
+*/}}
+{{- define "monochart.affinityRule.ShouldBeOnDifferentNode" -}}
+- weight: 100
+  podAffinityTerm:
+    labelSelector:
+      matchExpressions:
+      - key: app
+        operator: In
+        values:
+        - {{ include "common.name" . }}
+      - key: release
+        operator: In
+        values:
+        - {{ .Release.Name | quote }}
+    topologyKey: "kubernetes.io/hostname"
+{{- end -}}
+

--- a/incubator/monochart/templates/deployment.yaml
+++ b/incubator/monochart/templates/deployment.yaml
@@ -44,6 +44,30 @@ spec:
 {{- end }}
 {{- end }}
     spec:
+{{- if .Values.deployment.affinity }}
+      affinity:
+{{- if or .Values.deployment.affinity.podAntiAffinity (eq .Values.deployment.affinity.affinityRule "ShouldBeOnDifferentNode") }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+{{- if .Values.deployment.affinity.podAntiAffinity }}
+{{- if .Values.deployment.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution }}
+{{- with .Values.deployment.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution }}
+{{ toYaml . | indent 10 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if eq .Values.deployment.affinity.affinityRule "ShouldBeOnDifferentNode" }}
+{{- include "monochart.affinityRule.ShouldBeOnDifferentNode" . | nindent 10 }}
+{{- end }}
+{{- end }}
+{{- if .Values.deployment.affinity.podAffinity }}
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+{{- with .Values.deployment.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution }}
+{{ toYaml . | indent 10 }}
+{{- end }}
+{{- end }}
+{{- end }}
       containers:
       - name: {{ include "common.name" . }}
         image: {{ required "image.repository is required!" .Values.image.repository }}:{{ required "image.tag is required!" .Values.image.tag }}

--- a/incubator/monochart/values.example.yaml
+++ b/incubator/monochart/values.example.yaml
@@ -65,3 +65,20 @@ deployment:
     ## https://github.com/jtblin/kube2iam
     #  iam.amazonaws.com/role: role-arn
     labels: {}
+  affinity:
+    # use of simple rule
+    affinityRule: "ShouldBeOnDifferentNode"
+    # use custom affinity rule. Here app MUST be on different host then postgres instance for it
+    podAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app
+            operator: In
+            values:
+            - postgresql
+          - key: release
+            operator: In
+            values:
+            - "{{ requiredEnv "RELEASE_NAME" }}-postgresql"
+        topologyKey: "kubernetes.io/hostname"


### PR DESCRIPTION
## what
* deployment support pod affinity and anti-affinity
* single simple `affinityRule` added - `ShouldBeOnDifferentNode`

## why
* to be able to manage assigning pods to nodes
* to avoid repeating same common rules code in application chart values
