### PR TITLE
fix to avoid accessing port fields when it is null

### DIFF
--- a/incubator/monochart/Chart.yaml
+++ b/incubator/monochart/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A declarative helm chart for deploying common types of services on Kubernetes
 name: monochart
-version: 0.18.3
-appVersion: 0.18.3
+version: 0.18.4
+appVersion: 0.18.4
 home: https://github.com/cloudposse/charts/tree/master/incubator/monochart
 icon: https://raw.githubusercontent.com/cloudposse/charts/master/incubator/monochart/logo.png
 maintainers:

--- a/incubator/monochart/templates/daemonset.yaml
+++ b/incubator/monochart/templates/daemonset.yaml
@@ -53,9 +53,11 @@ spec:
 {{- end }}
         ports:
 {{- range $name, $port := .Values.service.ports }}
+{{- if $port }}
         - name: {{ $name }}
           containerPort: {{ $port.internal }}
           protocol: {{ default "TCP" $port.protocol  }}
+{{- end }}
 {{- end }}
         volumeMounts:
         - mountPath: {{ .Values.persistence.mountPath | quote }}

--- a/incubator/monochart/templates/deployment.yaml
+++ b/incubator/monochart/templates/deployment.yaml
@@ -87,9 +87,11 @@ spec:
 {{- end }}
         ports:
 {{- range $name, $port := .Values.service.ports }}
+{{- if $port }}
           - name: {{ $name }}
             containerPort: {{ $port.internal }}
             protocol: {{ default "TCP" $port.protocol  }}
+{{- end }}
 {{- end }}
         volumeMounts:
         - mountPath: {{ .Values.persistence.mountPath | quote }}

--- a/incubator/monochart/templates/service.yaml
+++ b/incubator/monochart/templates/service.yaml
@@ -19,10 +19,12 @@ spec:
 {{- else }}
   ports:
 {{- range $name, $port := .Values.service.ports }}
-  - port: {{ $port.external }}
-    targetPort: {{ $name }}
+{{- if $port }}
+  - targetPort: {{ $name }}
+    port: {{ $port.external }}
     protocol: {{ default "TCP" $port.protocol  }}
     name: {{ $name }}
+{{- end }}
 {{- end }}
 {{- if .Values.service.selector }}
 {{- with .Values.service.selector }}

--- a/incubator/monochart/templates/statefulset.yaml
+++ b/incubator/monochart/templates/statefulset.yaml
@@ -60,9 +60,11 @@ spec:
 {{- end }}
         ports:
 {{- range $name, $port := .Values.service.ports }}
+{{- if $port }}
         - name: {{ $name }}
           containerPort: {{ $port.internal }}
           protocol: {{ default "TCP" $port.protocol  }}
+{{- end }}
 {{- end }}
         volumeMounts:
         - mountPath: {{ .Values.statefulset.persistence.mountPath | quote }}


### PR DESCRIPTION
## what
* avoid accessing port when it is `null` in values

## why
* having port as `null` in values will fail helm chart with `nil pointer evaluating interface`