### PR TITLE
[nginx-default-backend] Add `selector` to `Deployment`

### DIFF
--- a/incubator/nginx-default-backend/Chart.yaml
+++ b/incubator/nginx-default-backend/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for nginx-default-backend to be used by nginx-ingress controller
 name: nginx-default-backend
-version: 0.4.0
+version: 0.5.0

--- a/incubator/nginx-default-backend/templates/deployment.yaml
+++ b/incubator/nginx-default-backend/templates/deployment.yaml
@@ -7,6 +7,10 @@ metadata:
     k8s-addon: ingress-nginx.addons.k8s.io
 spec:
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
+      k8s-addon: ingress-nginx.addons.k8s.io
   template:
     metadata:
       labels:


### PR DESCRIPTION
## what
* [nginx-default-backend] Add `selector` to `Deployment`

## why
* Newer Kubernetes version require `selector` to be present in `DeploymentSpec`
* Otherwise, the following error is thrown:

```
failed processing release ingress-backend: helm exited with status 1:
  Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Deployment.spec): missing required field "selector" in io.k8s.api.apps.v1.DeploymentSpec
```

## references
* https://stackoverflow.com/questions/59369174/unable-to-helm-install-due-to-deployment-manifest-issue
