### PR TITLE
[monochart] Add `envFrom` section

### DIFF
--- a/incubator/monochart/Chart.yaml
+++ b/incubator/monochart/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A declarative helm chart for deploying common types of services on Kubernetes
 name: monochart
-version: 0.18.4
-appVersion: 0.18.4
+version: 0.19.0
+appVersion: 0.19.0
 home: https://github.com/cloudposse/charts/tree/master/incubator/monochart
 icon: https://raw.githubusercontent.com/cloudposse/charts/master/incubator/monochart/logo.png
 maintainers:

--- a/incubator/monochart/templates/_helpers.tpl
+++ b/incubator/monochart/templates/_helpers.tpl
@@ -49,6 +49,16 @@ env:
     value: {{ default "" $value | quote }}
 {{- end }}
 {{- end }}
+{{- with $root.Values.envFrom }}
+{{- range $name := .configMaps -}}
+- configMapRef:
+    name: {{ $name }}
+{{- end }}
+{{- range $name := .secrets -}}
+- secretRef:
+    name: {{ $name }}
+{{- end }}
+{{- end }}
 {{- end -}}
 
 

--- a/incubator/monochart/values.example.yaml
+++ b/incubator/monochart/values.example.yaml
@@ -45,9 +45,18 @@ secrets:
       secret.test.txt: |-
         some text
 
-# Inline environment
+# Inline ENV variables
 env:
   INLINE_ENV_NAME: ENV_VALUE
+
+# ENV variables from existing Kubernetes secrets and ConfigMaps
+envFrom:
+  secrets:
+    - secret-1
+    - secret-2
+  configMaps:
+    - config-1
+    - config-2
 
 deployment:
   enabled: true

--- a/incubator/monochart/values.yaml
+++ b/incubator/monochart/values.yaml
@@ -51,9 +51,18 @@ secrets:
   #         group:
   #           key: value
 
-# Inline environment
+# Inline ENV variables
 env:
   # ENV_NAME: ENV_VALUE
+
+# ENV variables from existing Kubernetes secrets and ConfigMaps
+#envFrom:
+#  secrets:
+#    - secret-1
+#    - secret-2
+#  configMaps:
+#    - config-1
+#    - config-2
 
 deployment:
   enabled: false


### PR DESCRIPTION
## what
* [monochart] Add `envFrom` section

## why
* Allow converting existing Kubernetes secrets and config maps (without creating them) into ENV variables in pods that in turn can be accessed by the applications running in the pods

```
envFrom:
  secrets: 
   - secret-1
   - secret-2
  configMaps:
   - config-1
   - config-2
```
