### PR TITLE
[monochart] Add `serviceAccountName` attribute

### DIFF
--- a/incubator/monochart/templates/cronjob.yaml
+++ b/incubator/monochart/templates/cronjob.yaml
@@ -37,6 +37,9 @@ spec:
 {{ toYaml .| indent 12 }}
 {{- end }}
         spec:
+{{- if .Values.serviceAccountName }}
+          serviceAccountName: {{ .Values.serviceAccountName }}
+{{- end }}
           restartPolicy: '{{ default "Never" $cron.restartPolicy }}'
           containers:
           - name: {{ $root.Release.Name }}

--- a/incubator/monochart/templates/daemonset.yaml
+++ b/incubator/monochart/templates/daemonset.yaml
@@ -38,6 +38,9 @@ spec:
 {{ toYaml .| indent 8 }}
 {{- end }}
     spec:
+{{- if .Values.serviceAccountName }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
+{{- end }}
       containers:
       - name: {{ .Release.Name }}
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}

--- a/incubator/monochart/templates/deployment.yaml
+++ b/incubator/monochart/templates/deployment.yaml
@@ -44,6 +44,9 @@ spec:
 {{- end }}
 {{- end }}
     spec:
+{{- if .Values.serviceAccountName }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
+{{- end }}
 {{- if .Values.deployment.affinity }}
       affinity:
 {{- if or .Values.deployment.affinity.podAntiAffinity (eq .Values.deployment.affinity.affinityRule "ShouldBeOnDifferentNode") }}

--- a/incubator/monochart/templates/job.yaml
+++ b/incubator/monochart/templates/job.yaml
@@ -31,6 +31,9 @@ spec:
 {{ toYaml .| indent 8 }}
 {{- end }}
     spec:
+{{- if .Values.serviceAccountName }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
+{{- end }}
       restartPolicy: '{{ default "Never" $job.restartPolicy }}'
       containers:
       - name: {{ $root.Release.Name }}

--- a/incubator/monochart/templates/statefulset.yaml
+++ b/incubator/monochart/templates/statefulset.yaml
@@ -40,6 +40,9 @@ spec:
 {{ toYaml . | indent 4 }}
 {{- end }}
     spec:
+{{- if .Values.serviceAccountName }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
+{{- end }}
       terminationGracePeriodSeconds: 0
       containers:
       - name: {{ .Release.Name }}

--- a/incubator/monochart/values.example.yaml
+++ b/incubator/monochart/values.example.yaml
@@ -1,5 +1,7 @@
 replicaCount: 1
 
+serviceAccountName: my-service-account
+
 dockercfg:
   enabled: false
   image:

--- a/incubator/monochart/values.yaml
+++ b/incubator/monochart/values.yaml
@@ -1,5 +1,7 @@
 replicaCount: 1
 
+# serviceAccountName: my-service-account
+
 dockercfg:
   enabled: false
   # image:


### PR DESCRIPTION
## what
* [monochart] Add `serviceAccountName` attribute

## why
* To be able to provide an existing service account for pods (instead of using the default one)
