### PR TITLE
[fluentd-kubernetes-aws] Change metrics names and improve alerts by introducing absent checks

### DIFF
--- a/incubator/fluentd-kubernetes-aws/templates/prometheusrule.yaml
+++ b/incubator/fluentd-kubernetes-aws/templates/prometheusrule.yaml
@@ -17,7 +17,9 @@ spec:
   - name: fluentd
     rules:
     - alert: FluentdNodeDown
-      expr: up{job="{{ .Release.Name }}"} == 0
+      expr: |
+        up{job="{{ template "fluentd_kubernetes.name" . }}-prometheus"} == 0
+        or absent(up{job="{{ template "fluentd_kubernetes.name" . }}-prometheus"})
       for: 10m
       labels:
         service: fluentd
@@ -27,7 +29,9 @@ spec:
         description: Prometheus could not scrape {{ "{{ $labels.job }}" }} for more than 10 minutes
 
     - alert: FluentdNodeDown
-      expr: up{job="{{ .Release.Name }}"} == 0
+      expr: |
+        up{job="{{ template "fluentd_kubernetes.name" . }}-prometheus"} == 0
+        or absent(up{job="{{ template "fluentd_kubernetes.name" . }}-prometheus"})
       for: 30m
       labels:
         service: fluentd
@@ -37,7 +41,9 @@ spec:
         description: Prometheus could not scrape {{ "{{ $labels.job }}" }} for more than 30 minutes
 
     - alert: FluentdQueueLength
-      expr: rate(fluentd_status_buffer_queue_length[5m]) > 0.3
+      expr: |
+        rate(fluentd_output_status_buffer_queue_length[5m]) > 0.3
+        or absent(fluentd_output_status_buffer_queue_length)
       for: 1m
       labels:
         service: fluentd
@@ -47,7 +53,9 @@ spec:
         description: In the last 5 minutes, fluentd queues increased 30%. Current value is {{ "{{ $value }}" }}
 
     - alert: FluentdQueueLength
-      expr: rate(fluentd_status_buffer_queue_length[5m]) > 0.5
+      expr: |
+        rate(fluentd_output_status_buffer_queue_length[5m]) > 0.5
+        or absent(fluentd_output_status_buffer_queue_length)
       for: 1m
       labels:
         service: fluentd
@@ -57,7 +65,9 @@ spec:
         description: In the last 5 minutes, fluentd queues increased 50%. Current value is {{ "{{ $value }}" }}
 
     - alert: FluentdRecordsCountsHigh
-      expr: sum(rate(fluentd_record_counts{job="{{ .Release.Name }}"}[5m])) BY (instance) >  (3 * sum(rate(fluentd_record_counts{job="{{ .Release.Name }}"}[15m])) BY (instance))
+      expr: |
+        sum(rate(fluentd_output_status_emit_records{job="{{ template "fluentd_kubernetes.name" . }}-prometheus"}[5m])) BY (instance) >  (3 * sum(rate(fluentd_output_status_emit_records{job="{{ template "fluentd_kubernetes.name" . }}-prometheus"}[15m])) BY (instance))
+        or absent(fluentd_output_status_emit_records)
       for: 1m
       labels:
         service: fluentd


### PR DESCRIPTION
## What

* Reflect new metric names in alerts
* Added checks for absent metrics
* Change job to match `servicemonitor` configured

## Why

* Alerts were monitoring nonexistent metrics so they would never be triggered