### PR TITLE
Slightly better check for serviceAccountName's existence

### DIFF
--- a/incubator/monochart/templates/cronjob.yaml
+++ b/incubator/monochart/templates/cronjob.yaml
@@ -37,7 +37,7 @@ spec:
 {{ toYaml .| indent 12 }}
 {{- end }}
         spec:
-{{- if .Values.serviceAccountName }}
+{{- if index .Values "serviceAccountName" }}
           serviceAccountName: {{ .Values.serviceAccountName }}
 {{- end }}
           restartPolicy: '{{ default "Never" $cron.restartPolicy }}'

--- a/incubator/monochart/templates/daemonset.yaml
+++ b/incubator/monochart/templates/daemonset.yaml
@@ -38,7 +38,7 @@ spec:
 {{ toYaml .| indent 8 }}
 {{- end }}
     spec:
-{{- if .Values.serviceAccountName }}
+{{- if index .Values "serviceAccountName" }}
       serviceAccountName: {{ .Values.serviceAccountName }}
 {{- end }}
       containers:

--- a/incubator/monochart/templates/deployment.yaml
+++ b/incubator/monochart/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
 {{- end }}
 {{- end }}
     spec:
-{{- if .Values.serviceAccountName }}
+{{- if index .Values "serviceAccountName" }}
       serviceAccountName: {{ .Values.serviceAccountName }}
 {{- end }}
 {{- if .Values.deployment.affinity }}

--- a/incubator/monochart/templates/job.yaml
+++ b/incubator/monochart/templates/job.yaml
@@ -31,7 +31,7 @@ spec:
 {{ toYaml .| indent 8 }}
 {{- end }}
     spec:
-{{- if .Values.serviceAccountName }}
+{{- if index .Values "serviceAccountName" }}
       serviceAccountName: {{ .Values.serviceAccountName }}
 {{- end }}
       restartPolicy: '{{ default "Never" $job.restartPolicy }}'

--- a/incubator/monochart/templates/statefulset.yaml
+++ b/incubator/monochart/templates/statefulset.yaml
@@ -40,7 +40,7 @@ spec:
 {{ toYaml . | indent 4 }}
 {{- end }}
     spec:
-{{- if .Values.serviceAccountName }}
+{{- if index .Values "serviceAccountName" }}
       serviceAccountName: {{ .Values.serviceAccountName }}
 {{- end }}
       terminationGracePeriodSeconds: 0


### PR DESCRIPTION
Using just `if .Values.serviceAccountName` requires it to be defined, even if you aren't using it.

This allows it to be missing if not required.

Not sure if this is your preferred way to do it.