### PR TITLE
Update to k8s 1.16

### DIFF
--- a/incubator/monochart/Chart.yaml
+++ b/incubator/monochart/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A declarative helm chart for deploying common types of services on Kubernetes
 name: monochart
-version: 0.21.0
-appVersion: 0.21.0
+version: 0.22.0
+appVersion: 0.22.0
 home: https://github.com/cloudposse/charts/tree/master/incubator/monochart
 icon: https://raw.githubusercontent.com/cloudposse/charts/master/incubator/monochart/logo.png
 maintainers:

--- a/incubator/monochart/templates/cronjob.yaml
+++ b/incubator/monochart/templates/cronjob.yaml
@@ -2,7 +2,7 @@
 {{- range $name, $cron := .Values.cronjob -}}
 {{- if $cron.enabled }}
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "common.fullname" $root }}-{{ $name | replace "_" "-"  }}

--- a/incubator/monochart/templates/cronjob.yaml
+++ b/incubator/monochart/templates/cronjob.yaml
@@ -2,7 +2,7 @@
 {{- range $name, $cron := .Values.cronjob -}}
 {{- if $cron.enabled }}
 ---
-apiVersion: batch/v1
+apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: {{ include "common.fullname" $root }}-{{ $name | replace "_" "-"  }}

--- a/incubator/monochart/templates/ingress.yaml
+++ b/incubator/monochart/templates/ingress.yaml
@@ -3,7 +3,7 @@
 {{- range $name, $ingress := .Values.ingress -}}
 {{- if $ingress.enabled }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: extensions/v1
 kind: Ingress
 metadata:
 {{- with $ingress.annotations }}

--- a/incubator/monochart/templates/ingress.yaml
+++ b/incubator/monochart/templates/ingress.yaml
@@ -3,7 +3,7 @@
 {{- range $name, $ingress := .Values.ingress -}}
 {{- if $ingress.enabled }}
 ---
-apiVersion: extensions/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
 {{- with $ingress.annotations }}


### PR DESCRIPTION
### What
- Update monochart so that it is compatible with k8s 1.16

### Why
- Beta APIs were promoted to non-beta