### PR TITLE
Fix for Helm3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ services:
 
 install:
   - make init
-  - sudo make helm/install
+  - sudo make packages/install/helm packages/install/yq
   - make helm/repo/add-remote
   - make helm/repo/add-current
   - make docker/login


### PR DESCRIPTION
## what
* Avoid calling `helm init` which is deprecated

## why
* build-harness recently upgraded it's packages and this broke charts
* upstream build harness make target for `helm/install` is for helm2