### PR TITLE
[monochart] Update `envFrom`

### DIFF
--- a/incubator/monochart/templates/_helpers.tpl
+++ b/incubator/monochart/templates/_helpers.tpl
@@ -23,7 +23,7 @@ Environment template block for deployable resources
 */}}
 {{- define "monochart.env" -}}
 {{- $root := . -}}
-{{- if or $root.Values.configMaps $root.Values.secrets }}
+{{- if $root.Values.configMaps | or $root.Values.secrets | or $root.Values.envFrom }}
 envFrom:
 {{- range $name, $config := $root.Values.configMaps -}}
 {{- if $config.enabled }}
@@ -41,6 +41,18 @@ envFrom:
 {{- end }}
 {{- end }}
 {{- end }}
+{{- if $root.Values.envFrom }}
+{{- with $root.Values.envFrom }}
+{{- range $name := .configMaps }}
+- configMapRef:
+    name: {{ $name }}
+{{- end }}
+{{- range $name := .secrets }}
+- secretRef:
+    name: {{ $name }}
+{{- end }}
+{{- end }}
+{{- end -}}
 {{- end }}
 {{- with $root.Values.env }}
 env:
@@ -49,19 +61,6 @@ env:
     value: {{ default "" $value | quote }}
 {{- end }}
 {{- end }}
-{{- if $root.Values.envFrom }}
-envFrom:
-{{- with $root.Values.envFrom }}
-{{- range $name := .configMaps }}
-  - configMapRef:
-      name: {{ $name }}
-{{- end }}
-{{- range $name := .secrets }}
-  - secretRef:
-      name: {{ $name }}
-{{- end }}
-{{- end }}
-{{- end -}}
 {{- end -}}
 
 


### PR DESCRIPTION
## what
* Update `envFrom` section in `_helpers.tpl`

## why
* `envFrom` is a list of `EnvFromSource` and there could be only one `envFrom` in a Container spec (possibly with many `configMapRef` and `secretRef` parameters)
* The current implementation creates two `envFrom` sections, which is not correct behavior and will fail if we use these two configs at the same time:

```
envFrom:
  secrets:
    - secret-1
  configMaps:
    - config-1
```

and 

```
secrets:
  default:
    enabled: true
    mountPath: /secret-default
    annotations:
      test.secret.annotation: value
    labels:
      test_label: value
    env:
      SECRET_ENV_NAME: ENV_VALUE
    files:
      secret.test.txt: |-
        some text
```

* This update puts all `configMapRef` and `secretRef` parameters into just one `envFrom`  section
