### PR TITLE
[cert-manager] Deprecate chart

### DIFF
--- a/incubator/cert-manager/Chart.yaml
+++ b/incubator/cert-manager/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 name: cert-manager
-version: v0.7.0
+version: 0.8.0
+deprecated: true
 appVersion: v0.7.0
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager


### PR DESCRIPTION
## what

- Deprecate cert-manager chart

## why

- Per [request](https://github.com/helm/hub/issues/402#issuecomment-659404818) prior to deleting the chart, as outlined in [Helm documentation](https://helm.sh/docs/topics/charts/#deprecating-charts)

## references

- Prerequisite to #252 