### PR TITLE
[fluentd-kubernetes-aws] Fix syntax error

### DIFF
--- a/incubator/fluentd-kubernetes-aws/Chart.yaml
+++ b/incubator/fluentd-kubernetes-aws/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Collect Kubernetes logs with Fluentd and forward to AWS-hosted Elasticsearch.
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
 name: fluentd-kubernetes-aws
-version: 0.2.0
+version: 0.2.1
 appVersion: 1.4.2
 home: https://www.fluentd.org/
 sources:

--- a/incubator/fluentd-kubernetes-aws/templates/daemonset.yaml
+++ b/incubator/fluentd-kubernetes-aws/templates/daemonset.yaml
@@ -54,7 +54,7 @@ spec:
             value: "https"
         {{- end }}
           {{- range $name, $value := .Values.env }}
-          {{- if (not (empty $value)) and (not (eq $name "FLUENT_ELASTICSEARCH_HOST" "FLUENT_ELASTICSEARCH_SCHEME")) }}
+          {{- if and (not (empty $value)) (not (eq $name "FLUENT_ELASTICSEARCH_HOST" "FLUENT_ELASTICSEARCH_SCHEME")) }}
           - name: {{ $name | quote }}
             value: {{ $value | quote }}
           {{- end }}


### PR DESCRIPTION
## what
- [fluentd-kubernetes-aws] Fix syntax error

## why
- Chart would fail if environment variables were set