### PR TITLE
[monochart] Fix bugs, remove dependency on obsolescent Kubernetes repo

### DIFF
--- a/incubator/monochart/Chart.yaml
+++ b/incubator/monochart/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A declarative helm chart for deploying common types of services on Kubernetes
 name: monochart
-version: 0.22.0
-appVersion: 0.22.0
+version: 0.23.0
+appVersion: 0.23.0
 home: https://github.com/cloudposse/charts/tree/master/incubator/monochart
 icon: https://raw.githubusercontent.com/cloudposse/charts/master/incubator/monochart/logo.png
 maintainers:

--- a/incubator/monochart/requirements.yaml
+++ b/incubator/monochart/requirements.yaml
@@ -1,7 +1,4 @@
 dependencies:
-- name: common
-  version: 0.0.4
-  repository: https://kubernetes-charts-incubator.storage.googleapis.com/
 - name: dockercfg
   version: 0.1.0
   repository: https://charts.cloudposse.com/incubator/

--- a/incubator/monochart/templates/_common_fullname.tpl
+++ b/incubator/monochart/templates/_common_fullname.tpl
@@ -1,0 +1,42 @@
+{{- /*
+From obsolete Kubernetes Incubator Common chart
+https://github.com/helm/charts/blob/master/incubator/common/
+
+fullname defines a suitably unique name for a resource by combining
+the release name and the chart name.
+
+The prevailing wisdom is that names should only contain a-z, 0-9 plus dot (.) and dash (-), and should
+not exceed 63 characters.
+
+Parameters:
+
+- .Values.fullnameOverride: Replaces the computed name with this given name
+- .Values.fullnamePrefix: Prefix
+- .Values.global.fullnamePrefix: Global prefix
+- .Values.fullnameSuffix: Suffix
+- .Values.global.fullnameSuffix: Global suffix
+
+The applied order is: "global prefix + prefix + name + suffix + global suffix"
+
+Usage: 'name: "{{- template "common.fullname" . -}}"'
+*/ -}}
+{{- define "common.fullname"}}
+    {{- $global := default (dict) .Values.global -}}
+    {{- $base := default (printf "%s-%s" .Release.Name .Chart.Name) .Values.fullnameOverride -}}
+    {{- $gpre := default "" $global.fullnamePrefix -}}
+    {{- $pre := default "" .Values.fullnamePrefix -}}
+    {{- $suf := default "" .Values.fullnameSuffix -}}
+    {{- $gsuf := default "" $global.fullnameSuffix -}}
+    {{- $name := print $gpre $pre $base $suf $gsuf -}}
+    {{- $name | lower | trunc 54 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- /*
+common.fullname.unique adds a random suffix to the unique name.
+
+This takes the same parameters as common.fullname
+
+*/ -}}
+{{- define "common.fullname.unique" -}}
+    {{ template "common.fullname" . }}-{{ randAlphaNum 7 | lower }}
+{{- end }}

--- a/incubator/monochart/templates/_common_metadata_labels.tpl
+++ b/incubator/monochart/templates/_common_metadata_labels.tpl
@@ -1,0 +1,46 @@
+{{- /*
+From obsolete Kubernetes Incubator Common chart
+https://github.com/helm/charts/blob/master/incubator/common/
+
+common.labelize takes a dict or map and generates labels.
+
+Values will be quoted. Keys will not.
+
+Example output:
+
+  first: "Matt"
+  last: "Butcher"
+
+*/ -}}
+{{- define "common.labelize" -}}
+    {{- range $k, $v := . }}
+        {{ $k }}: {{ $v | quote }}
+    {{- end -}}
+{{- end -}}
+
+{{- /*
+common.chartref prints a chart name and version.
+
+It does minimal escaping for use in Kubernetes labels.
+
+Example output:
+
+  zookeeper-1.2.3
+  wordpress-3.2.1_20170219
+
+*/ -}}
+{{- define "common.chartref" -}}
+    {{- replace "+" "_" .Chart.Version | printf "%s-%s" .Chart.Name -}}
+{{- end -}}
+
+{{- /*
+common.labels.standard prints the standard Helm labels.
+
+The standard labels are frequently used in metadata.
+*/ -}}
+{{- define "common.labels.standard" -}}
+app: {{ template "common.name" . }}
+chart: {{ template "common.chartref" . }}
+heritage: {{ .Release.Service | quote }}
+release: {{ .Release.Name | quote }}
+{{- end -}}

--- a/incubator/monochart/templates/_common_name.tpl
+++ b/incubator/monochart/templates/_common_name.tpl
@@ -1,0 +1,32 @@
+{{- /*
+From obsolete Kubernetes Incubator Common chart
+https://github.com/helm/charts/blob/master/incubator/common/
+
+name defines a template for the name of the chart. It should be used for the `app` label.
+This is common practice in many Kubernetes manifests, and is not Helm-specific.
+
+The prevailing wisdom is that names should only contain a-z, 0-9 plus dot (.) and dash (-), and should
+not exceed 63 characters.
+
+Parameters:
+
+- .Values.nameOverride: Replaces the computed name with this given name
+- .Values.namePrefix: Prefix
+- .Values.global.namePrefix: Global prefix
+- .Values.nameSuffix: Suffix
+- .Values.global.nameSuffix: Global suffix
+
+The applied order is: "global prefix + prefix + name + suffix + global suffix"
+
+Usage: 'name: "{{- template "common.name" . -}}"'
+*/ -}}
+{{- define "common.name"}}
+    {{- $global := default (dict) .Values.global -}}
+    {{- $base := default .Chart.Name .Values.nameOverride -}}
+    {{- $gpre := default "" $global.namePrefix -}}
+    {{- $pre := default "" .Values.namePrefix -}}
+    {{- $suf := default "" .Values.nameSuffix -}}
+    {{- $gsuf := default "" $global.nameSuffix -}}
+    {{- $name := print $gpre $pre $base $suf $gsuf -}}
+    {{- $name | lower | trunc 54 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/monochart/templates/job.yaml
+++ b/incubator/monochart/templates/job.yaml
@@ -31,8 +31,8 @@ spec:
 {{ toYaml .| indent 8 }}
 {{- end }}
     spec:
-{{- if index .Values "serviceAccountName" }}
-      serviceAccountName: {{ .Values.serviceAccountName }}
+{{- if index $root.Values "serviceAccountName" }}
+      serviceAccountName: {{ $root.Values.serviceAccountName }}
 {{- end }}
       restartPolicy: '{{ default "Never" $job.restartPolicy }}'
       containers:

--- a/incubator/monochart/values.yaml
+++ b/incubator/monochart/values.yaml
@@ -19,7 +19,7 @@ image:
   #   - "docker-secret-1"
   #   - "docker-secret-2"
 
-configMaps:
+configMaps: {}
   # default:
   #   enabled: false
   #   mountPath: /config-default
@@ -36,7 +36,7 @@ configMaps:
   #         group:
   #           key: value
 
-secrets:
+secrets: {}
   # default:
   #   enabled: false
   #   mountPath: /secret-default
@@ -54,7 +54,7 @@ secrets:
   #           key: value
 
 # Inline ENV variables
-env:
+env: {}
   # ENV_NAME: ENV_VALUE
 
 # ENV variables from existing Kubernetes secrets and ConfigMaps
@@ -218,7 +218,7 @@ service:
 ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/service-monitor.md
 ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitorspec
 ##
-serviceMonitors:
+serviceMonitors: {}
 #  ## Name of the ServiceMonitor to create
 #  ##
 #  name:
@@ -302,7 +302,7 @@ serviceMonitors:
 #          # serverName: ""
 
 ## https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusrulespec
-prometheusRules:
+prometheusRules: {}
 #  name:
 #    labels:
 #      prometheus: kube-prometheus
@@ -318,7 +318,7 @@ prometheusRules:
 #          description: Reloading Prometheus' configuration has failed for {{$labels.namespace}}/{{$labels.pod}}
 #          summary: Reloading Promehteus' configuration failed
 
-probes:
+probes: {}
 #  livenessProbe:
 #    httpGet:
 #      path: /
@@ -328,7 +328,7 @@ probes:
 #      path: /
 #      port: http
 
-resources:
+resources: {}
 #  limits:
 #    cpu: 100m
 #    memory: 128Mi
@@ -405,7 +405,7 @@ virtualServices:
 #          subset: v1
 
 
-crd:
+crd: {}
 #  "networking.istio.io/v1alpha3":
 #    ServiceEntry:
 #      default:


### PR DESCRIPTION
## what

In [monochart]:
- Fix incorrect reference to `serviceAccount` in `jobs.yaml`
- Use empty maps rather than `nil` for default empty map values
- Remove dependency on obsolescent Kubernetes incubator Helm repo by copying needed templates

## why
- Caused error when defining a job
- Caused unnecessary warning messages
- Repo scheduled to be marked obsolete on Nov 13, 2020