### PR TITLE
Fixes bad check for serviceAccountName

### DIFF
--- a/incubator/monochart/Chart.yaml
+++ b/incubator/monochart/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A declarative helm chart for deploying common types of services on Kubernetes
 name: monochart
-version: 0.23.0
-appVersion: 0.23.0
+version: 0.23.1
+appVersion: 0.23.1
 home: https://github.com/cloudposse/charts/tree/master/incubator/monochart
 icon: https://raw.githubusercontent.com/cloudposse/charts/master/incubator/monochart/logo.png
 maintainers:

--- a/incubator/monochart/templates/cronjob.yaml
+++ b/incubator/monochart/templates/cronjob.yaml
@@ -37,8 +37,8 @@ spec:
 {{ toYaml .| indent 12 }}
 {{- end }}
         spec:
-{{- if index .Values "serviceAccountName" }}
-          serviceAccountName: {{ .Values.serviceAccountName }}
+{{- if index $root.Values "serviceAccountName" }}
+          serviceAccountName: {{ $root.Values.serviceAccountName }}
 {{- end }}
           restartPolicy: '{{ default "Never" $cron.restartPolicy }}'
           containers:


### PR DESCRIPTION
When not defined, the cronjob fails in helm with:
```
  Error: Failed to render chart: exit status 1: Error: template: monochart/templates/cronjob.yaml:40:7: executing "monochart/templates/cronjob.yaml"
 at <index .Values "serviceAccountName">: error calling index: index of untyped nil     
```
This should fix that.