### PR TITLE
[monochart] make persistence optional, fix SS labels

### DIFF
--- a/incubator/monochart/Chart.yaml
+++ b/incubator/monochart/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A declarative helm chart for deploying common types of services on Kubernetes
 name: monochart
-version: 0.23.1
-appVersion: 0.23.1
+version: 0.23.2
+appVersion: 0.23.2
 home: https://github.com/cloudposse/charts/tree/master/incubator/monochart
 icon: https://raw.githubusercontent.com/cloudposse/charts/master/incubator/monochart/logo.png
 maintainers:

--- a/incubator/monochart/templates/deployment.yaml
+++ b/incubator/monochart/templates/deployment.yaml
@@ -97,9 +97,11 @@ spec:
 {{- end }}
 {{- end }}
         volumeMounts:
+        {{- if .Values.persistence.enabled }}
         - mountPath: {{ .Values.persistence.mountPath | quote }}
           name: storage
-{{ include "monochart.files.volumeMounts" . | indent 8 }}
+        {{- end }}
+        {{- include "monochart.files.volumeMounts" . |  nindent 8 }}
 {{- with .Values.probes }}
 {{ toYaml . | indent 8 }}
 {{- end }}
@@ -121,8 +123,8 @@ spec:
       {{- end }}
 {{- end }}
       volumes:
+      {{- if .Values.persistence.enabled }}
       - name: storage
-      {{- if .Values.persistence }}
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:
           claimName: {{ .Values.persistence.existingClaim | default (include "common.fullname" .) }}
@@ -130,5 +132,5 @@ spec:
         emptyDir: {}
       {{- end }}
       {{- end }}
-{{ include "monochart.files.volumes" . | indent 6 }}
+      {{- include "monochart.files.volumes" . | nindent 6 }}
 {{- end -}}

--- a/incubator/monochart/templates/statefulset.yaml
+++ b/incubator/monochart/templates/statefulset.yaml
@@ -28,8 +28,10 @@ spec:
   template:
     metadata:
       name: {{ include "common.fullname" . }}
-{{- with .Values.statefulset.pod.annotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+{{- with .Values.statefulset.pod.annotations }}
 {{ toYaml . | indent 8 }}
 {{- end }}
       labels:
@@ -37,13 +39,37 @@ spec:
         release: {{ .Release.Name | quote }}
         serve: "true"
 {{- with .Values.statefulset.pod.labels }}
-{{ toYaml . | indent 4 }}
+{{ toYaml . | indent 8 }}
 {{- end }}
     spec:
 {{- if index .Values "serviceAccountName" }}
       serviceAccountName: {{ .Values.serviceAccountName }}
 {{- end }}
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: {{ .Values.statefulset.terminationGracePeriodSeconds }}
+{{- if .Values.statefulset.affinity }}
+      affinity:
+{{- if or .Values.statefulset.affinity.podAntiAffinity (eq .Values.statefulset.affinity.affinityRule "ShouldBeOnDifferentNode") }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+{{- if .Values.statefulset.affinity.podAntiAffinity }}
+{{- if .Values.statefulset.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution }}
+{{- with .Values.statefulset.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution }}
+{{ toYaml . | indent 10 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if eq .Values.statefulset.affinity.affinityRule "ShouldBeOnDifferentNode" }}
+{{- include "monochart.affinityRule.ShouldBeOnDifferentNode" . | nindent 10 }}
+{{- end }}
+{{- end }}
+{{- if .Values.statefulset.affinity.podAffinity }}
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+{{- with .Values.statefulset.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution }}
+{{ toYaml . | indent 10 }}
+{{- end }}
+{{- end }}
+{{- end }}
       containers:
       - name: {{ .Release.Name }}
         image: {{ required "image.repository is required!" .Values.image.repository }}:{{ required "image.tag is required!" .Values.image.tag }}
@@ -70,9 +96,11 @@ spec:
 {{- end }}
 {{- end }}
         volumeMounts:
+        {{- if .Values.statefulset.persistence.enabled }}
         - mountPath: {{ .Values.statefulset.persistence.mountPath | quote }}
           name: {{ include "common.fullname" . }}
-{{ include "monochart.files.volumeMounts" . | indent 8 }}
+        {{- end }}
+        {{- include "monochart.files.volumeMounts" . | nindent 8 }}
 {{- with .Values.probes }}
 {{ toYaml . | indent 8 }}
 {{- end }}
@@ -95,6 +123,7 @@ spec:
 {{- end }}
       volumes:
 {{ include "monochart.files.volumes" . | indent 6 }}
+{{- if .Values.statefulset.persistence.enabled }}
 {{- if not .Values.statefulset.persistence.useVolumeClaimTemplates }}
       - name: {{ (include "common.fullname" . ) }}
         persistentVolumeClaim:
@@ -124,6 +153,7 @@ spec:
       storageClassName: ""
 {{- else }}
       storageClassName: {{ .Values.statefulset.persistence.storageClass | quote }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/incubator/monochart/values.yaml
+++ b/incubator/monochart/values.yaml
@@ -97,6 +97,7 @@ statefulset:
   ## ref: https://v1-10.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#statefulsetupdatestrategy-v1-apps
   # strategy: {}
   revisionHistoryLimit: 10
+  terminationGracePeriodSeconds: 10
   # annotations:
   #   name: value
   # labels:
@@ -116,6 +117,7 @@ statefulset:
     # args:
   ## Configure volumeClaimTemplate block
   persistence:
+    enabled: true
     useVolumeClaimTemplates: true
     accessMode: ReadWriteOnce
     size: 8Gi


### PR DESCRIPTION
## what

Changes to [monochart]
- Make StatefulSet.terminationGracePeriod configurable
- Make persistence optional for Deployments and StatefulSets
- Fix pod labels in StatefulSets
- Add podAffinity/podAntiAffinity options to StatefulSets

## why 
- Was not configurable and was set to zero, which is explicitly discouraged in Kubernetes documentation (now defaults to 10)
- Deployments used `emptyDir` storage by default, which make the Cluster AutoScaler unwilling to move them. StatefulSets required a PersistentVolume even though not strictly required.
- Indentation error broke pod labels for StatefulSets
- StatefulSets benefit from podAntiAffinity even more than Deployments do