### PR TITLE
[monochart] Add `envFromFieldRefFieldPath` config

### DIFF
--- a/incubator/monochart/Chart.yaml
+++ b/incubator/monochart/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A declarative helm chart for deploying common types of services on Kubernetes
 name: monochart
-version: 0.23.2
-appVersion: 0.23.2
+version: 0.24.0
+appVersion: 0.24.0
 home: https://github.com/cloudposse/charts/tree/master/incubator/monochart
 icon: https://raw.githubusercontent.com/cloudposse/charts/master/incubator/monochart/logo.png
 maintainers:

--- a/incubator/monochart/templates/_helpers.tpl
+++ b/incubator/monochart/templates/_helpers.tpl
@@ -61,6 +61,18 @@ env:
     value: {{ default "" $value | quote }}
 {{- end }}
 {{- end }}
+{{/*
+https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/#use-pod-fields-as-values-for-environment-variables
+*/}}
+{{- with $root.Values.envFromFieldRefFieldPath }}
+env:
+{{- range $name, $value := . }}
+  - name: {{ $name }}
+    valueFrom:
+      fieldRef:
+        fieldPath: {{ $value }}
+{{- end }}
+{{- end }}
 {{- end -}}
 
 

--- a/incubator/monochart/values.example.yaml
+++ b/incubator/monochart/values.example.yaml
@@ -60,6 +60,12 @@ envFrom:
     - config-1
     - config-2
 
+# ENV variables from fieldRef.fieldPath
+# https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/#use-pod-fields-as-values-for-environment-variables
+envFromFieldRefFieldPath:
+  ENV_1: path-1
+  ENV_2: path-2
+
 deployment:
   enabled: true
   ## Pods replace strategy

--- a/incubator/monochart/values.yaml
+++ b/incubator/monochart/values.yaml
@@ -66,6 +66,12 @@ env: {}
 #    - config-1
 #    - config-2
 
+# ENV variables from fieldRef.fieldPath
+# https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/#use-pod-fields-as-values-for-environment-variables
+#envFromFieldRefFieldPath:
+#  ENV_1: path-1
+#  ENV_2: path-2
+
 deployment:
   enabled: false
   ## Pods replace strategy


### PR DESCRIPTION
## what
* [monochart] Add `envFromFieldRefFieldPath` config

## why
* To be able to declare ENV vars from pod fields
* Example usage is Datadog APM to declare dynamic ENV var `DD_AGENT_HOST` from pod field `status.hostIP`

## references
* https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm
* https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/#use-pod-fields-as-values-for-environment-variables
