### PR TITLE
Improve Monochart Service port mapping

### DIFF
--- a/incubator/monochart/templates/service.yaml
+++ b/incubator/monochart/templates/service.yaml
@@ -20,7 +20,7 @@ spec:
   ports:
 {{- range $name, $port := .Values.service.ports }}
 {{- if $port }}
-  - targetPort: {{ $name }}
+  - targetPort: {{ $port.internal }}
     port: {{ $port.external }}
     protocol: {{ default "TCP" $port.protocol  }}
     name: {{ $name }}

--- a/incubator/monochart/values.yaml
+++ b/incubator/monochart/values.yaml
@@ -214,9 +214,10 @@ service:
   enabled: false
   type: ClusterIP
   ports:
-    default:
-      internal: 8080
-      external: 80
+    http:               #Name of the Port for Multi-Port Services
+      internal: 8080    #This is the targetPort for the application/deployment/etc.
+      external: 80      #This is the incoming port
+      protocol: TCP
   # labels:
   #   name: value
   # annotations:


### PR DESCRIPTION
As in the `values.yaml` use the `$port.internal` variable to set the target port instead of using the `$name`.
This is a more clear and easy way to understand how the service port mapping works.
Also updated the `values.yaml` with simple explanation comments.