### PR TITLE
[incubator/service-level-operator] Fix namespace used by the ServiceAccountBinding in chart

### DIFF
--- a/incubator/service-level-operator/Chart.yaml
+++ b/incubator/service-level-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Service level operator abstracts and automates the service level of Kubernetes applications by generation SLI & SLOs to be consumed easily by dashboards and alerts and allow that the SLI/SLO's live with the application flow.
 name: service-level-operator
-version: 0.1.0
+version: 0.1.1
 appVersion: "v0.2.0"
 home: https://github.com/spotahome/service-level-operator
 sources:

--- a/incubator/service-level-operator/Chart.yaml
+++ b/incubator/service-level-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Service level operator abstracts and automates the service level of Kubernetes applications by generation SLI & SLOs to be consumed easily by dashboards and alerts and allow that the SLI/SLO's live with the application flow.
 name: service-level-operator
 version: 0.1.1
-appVersion: "v0.2.0"
+appVersion: "v0.3.0"
 home: https://github.com/spotahome/service-level-operator
 sources:
 - https://github.com/spotahome/service-level-operator

--- a/incubator/service-level-operator/templates/clusterrolebinding.yaml
+++ b/incubator/service-level-operator/templates/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ include "service-operator.name" . }}
-    namespace: monitoring
+    namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/incubator/service-level-operator/templates/servicemonitor.yaml
+++ b/incubator/service-level-operator/templates/servicemonitor.yaml
@@ -13,7 +13,7 @@ spec:
       component: app
   namespaceSelector:
     matchNames:
-      - monitoring
+      - {{ .Release.Namespace }}
   endpoints:
     - port: http
-      interval: 10s
+      interval: {{ .Values.serviceMonitor.interval }}

--- a/incubator/service-level-operator/values.yaml
+++ b/incubator/service-level-operator/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 ## Set default image, imageTag, and imagePullPolicy.
 image:
   repository: quay.io/spotahome/service-level-operator
-  tag: "v0.2.0"
+  tag: "v0.3.0"
   pullPolicy: "IfNotPresent"
 readinessProbe:
   httpGet:

--- a/incubator/service-level-operator/values.yaml
+++ b/incubator/service-level-operator/values.yaml
@@ -25,3 +25,5 @@ resources:
     cpu: 120m
     memory: 128Mi
 prometheus: prometheus-operator-prometheus
+serviceMonitor:
+  interval: 10s


### PR DESCRIPTION
The chart has hardcoded the namespace to use (`monitoring`) in the ServiceAccountBinding, making the image to fail when it tries to create the CRD.
```
error running app: error creating crd servicelevels.monitoring.spotahome.com: customresourcedefinitions.apiextensions.k8s.io is forbidden: User "system:serviceaccount:#REAL-NAMESPACE#:service-level-operator" cannot create resource "customresourcedefinitions" in API group "apiextensions.k8s.io" at the cluster scope
```
Once fixed the image can create the CRD without any problem.