### PR TITLE
Adds ability to use secretKeyRef in env spec

### DIFF
--- a/incubator/monochart/Chart.yaml
+++ b/incubator/monochart/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A declarative helm chart for deploying common types of services on Kubernetes
 name: monochart
-version: 0.24.0
-appVersion: 0.24.0
+version: 0.25.0
+appVersion: 0.25.0
 home: https://github.com/cloudposse/charts/tree/master/incubator/monochart
 icon: https://raw.githubusercontent.com/cloudposse/charts/master/incubator/monochart/logo.png
 maintainers:

--- a/incubator/monochart/templates/_helpers.tpl
+++ b/incubator/monochart/templates/_helpers.tpl
@@ -73,6 +73,18 @@ env:
         fieldPath: {{ $value }}
 {{- end }}
 {{- end }}
+{{/*
+https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables
+*/}}
+{{- with $root.Values.envFromSecretKeyRef }}
+{{- range $data := . }}
+  - name: {{ $data.name }}
+    valueFrom:
+      secretKeyRef:
+        name: {{ $data.secret }}
+        key: {{ $data.key }}
+{{- end }}
+{{- end }}
 {{- end -}}
 
 

--- a/incubator/monochart/values.example.yaml
+++ b/incubator/monochart/values.example.yaml
@@ -66,6 +66,13 @@ envFromFieldRefFieldPath:
   ENV_1: path-1
   ENV_2: path-2
 
+# ENV variables from  secretkeyref
+# https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables
+envFromSecretKeyRef:
+  - name: MY_ENV_VARIABLE
+    secret: kubernetes-secret-name
+    key: key-name-in-secret
+
 deployment:
   enabled: true
   ## Pods replace strategy

--- a/incubator/monochart/values.yaml
+++ b/incubator/monochart/values.yaml
@@ -72,6 +72,13 @@ env: {}
 #  ENV_1: path-1
 #  ENV_2: path-2
 
+# ENV variables from  secretkeyref
+# https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables
+# envFromSecretKeyRef:
+#   - name: MY_ENV_VARIABLE
+#     secret: kubernetes-secret-name
+#     key: key-name-in-secret
+
 deployment:
   enabled: false
   ## Pods replace strategy


### PR DESCRIPTION
## what
Adds the ability to use the `secretKeyRef` style of adding environment variables to kubernetes specs.

## why
While this is already provided via `envFrom` in this chart, and the corresponding kubernetes features, envFrom doesn't allow you to specify the target environment variable name in your pods, nor does it allow you to use keys in your secrets that aren't valid environment variable names.

## reference
* https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables

## example
Providing this value:
```yaml
        envFromSecretKeyRef:
          - name: CELERY_BROKER_USERNAME
            secret: example-rabbitmq-default-user
            key: username
          - name: CELERY_BROKER_PASSWORD
            secret: example-rabbitmq-default-user
            key: password
```
Would add the following to the template:
```yaml
        env:
          - name: CELERY_BROKER_USERNAME
            valueFrom:
              secretKeyRef:
                name: example-rabbitmq-default-user
                key: username
          - name: CELERY_BROKER_PASSWORD
            valueFrom:
              secretKeyRef:
                name: example-rabbitmq-default-user
                key: password
```