### PR TITLE
Fix bad yaml when only secretKeyRef

### DIFF
--- a/incubator/monochart/Chart.yaml
+++ b/incubator/monochart/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A declarative helm chart for deploying common types of services on Kubernetes
 name: monochart
-version: 0.25.0
-appVersion: 0.25.0
+version: 0.25.1
+appVersion: 0.25.1
 home: https://github.com/cloudposse/charts/tree/master/incubator/monochart
 icon: https://raw.githubusercontent.com/cloudposse/charts/master/incubator/monochart/logo.png
 maintainers:

--- a/incubator/monochart/templates/_helpers.tpl
+++ b/incubator/monochart/templates/_helpers.tpl
@@ -64,8 +64,9 @@ env:
 {{/*
 https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/#use-pod-fields-as-values-for-environment-variables
 */}}
-{{- with $root.Values.envFromFieldRefFieldPath }}
+{{- if or (not (empty $root.Values.envFromFieldRefFieldPath)) (not (empty $root.Values.envFromSecretKeyRef)) }}
 env:
+{{- with $root.Values.envFromFieldRefFieldPath }}
 {{- range $name, $value := . }}
   - name: {{ $name }}
     valueFrom:
@@ -83,6 +84,7 @@ https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-envir
       secretKeyRef:
         name: {{ $data.secret }}
         key: {{ $data.key }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end -}}


### PR DESCRIPTION
Found a bug with my previous feature.

If you specified *only* a secretKeyRef, and not an accompanying fieldRef, the `env:` tag would be missing in the yaml section, causing invalid yaml as such:
```
      containers:
      - name: mything
        image: mything:latest
        imagePullPolicy: Always

        envFrom:
        - configMapRef:
            name: mything-env-default

          - name: MYTHING_USERNAME
            valueFrom:
              secretKeyRef:
                name: mything-user
                key: username
          - name: MYTHING_PASSWORD
            valueFrom:
              secretKeyRef:
                name: mything-user
                key: password
```
This fixes this bug, so that if either fieldKeyRef or secretKeyRefs are referenced, the env: section will have the appropriate yaml
```
      containers:
      - name: mything
        image: mything:latest
        imagePullPolicy: Always

        envFrom:
        - configMapRef:
            name: mything-env-default

        env:

          - name: MYTHING_USERNAME
            valueFrom:
              secretKeyRef:
                name: mything-user
                key: username
          - name: MYTHING_PASSWORD
            valueFrom:
              secretKeyRef:
                name: mything-user
                key: password
```