### PR TITLE
git.io->cloudposse.tools update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
--include $(shell curl -sSL -o .build-harness "https://git.io/build-harness"; echo .build-harness)
+-include $(shell curl -sSL -o .build-harness "https://cloudposse.tools/build-harness"; echo .build-harness)
 build:
 	docker run -v $(CURDIR)/incubator:/build-harness/incubator -v $(CURDIR)/packages:/build-harness/packages \
 		-e HELM_CHART_REPO_URL=https://charts.cloudposse.com/incubator \


### PR DESCRIPTION
## what and why
Change all references to `git.io/build-harness` into `cloudposse.tools/build-harness`, since `git.io` redirects will stop working on April 29th, 2022.

## References
- DEV-143