### PR TITLE
Revert "`[Monochart]` Feature: `deployment.yaml` volume mounts (#273)"

### DIFF
--- a/incubator/monochart/templates/_helpers.tpl
+++ b/incubator/monochart/templates/_helpers.tpl
@@ -61,16 +61,11 @@ env:
     value: {{ default "" $value | quote }}
 {{- end }}
 {{- end }}
-
 {{/*
 https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/#use-pod-fields-as-values-for-environment-variables
 */}}
 {{- with $root.Values.envFromFieldRefFieldPath }}
-
-{{/* Only add env block if not used by above .Values.env */}}
-{{- if not $root.Values.env}}
 env:
-{{- end }}
 {{- range $name, $value := . }}
   - name: {{ $name }}
     valueFrom:

--- a/incubator/monochart/templates/deployment.yaml
+++ b/incubator/monochart/templates/deployment.yaml
@@ -96,17 +96,12 @@ spec:
             protocol: {{ default "TCP" $port.protocol  }}
 {{- end }}
 {{- end }}
-        {{- if or .Values.deployment.pod.volumeMounts .Values.persistence.enabled .Values.configMaps.enabled .Values.secrets.enabled }}
         volumeMounts:
-        {{- if .Values.deployment.pod.volumeMounts }}
-        {{- toYaml .Values.deployment.pod.volumeMounts | nindent 8 }}
-        {{- end }}
         {{- if .Values.persistence.enabled }}
         - mountPath: {{ .Values.persistence.mountPath | quote }}
           name: storage
         {{- end }}
         {{- include "monochart.files.volumeMounts" . |  nindent 8 }}
-        {{- end }}
 {{- with .Values.probes }}
 {{ toYaml . | indent 8 }}
 {{- end }}
@@ -114,26 +109,20 @@ spec:
         resources:
 {{ toYaml . | indent 10 }}
 {{- end }}
-      {{- with .Values.deployment.pod.hostAliases }}
+{{- with .Values.deployment.pod.hostAliases }}
       hostAliases:
-        {{- toYaml . | indent 8 }}
-      {{- end }}
-    {{- if or .Values.dockercfg.enabled .Values.image.pullSecrets }}
+{{ toYaml . | indent 8 }}
+{{- end }}
       imagePullSecrets:
-    {{- end }}
-      {{- if .Values.dockercfg.enabled }}
+{{- if .Values.dockercfg.enabled }}
         - name: {{ include "common.fullname" . }}
-      {{- end }}
-    {{- with .Values.image.pullSecrets }}
+{{- end }}
+{{- with .Values.image.pullSecrets }}
       {{- range . }}
         - name: {{ . }}
       {{- end }}
-    {{- end }}
-    {{- if or .Values.deployment.volumes .Values.persistence.enabled .Values.configMaps.enabled .Values.secrets.enabled }}
+{{- end }}
       volumes:
-      {{- if .Values.deployment.volumes }}
-        {{- toYaml .Values.deployment.volumes | nindent 6 }}
-      {{- end }}
       {{- if .Values.persistence.enabled }}
       - name: storage
       {{- if .Values.persistence.enabled }}
@@ -144,6 +133,4 @@ spec:
       {{- end }}
       {{- end }}
       {{- include "monochart.files.volumes" . | nindent 6 }}
-      {{- end }}
-      
 {{- end -}}

--- a/incubator/monochart/test/full.yaml
+++ b/incubator/monochart/test/full.yaml
@@ -65,16 +65,6 @@ deployment:
     ## https://github.com/jtblin/kube2iam
     #  iam.amazonaws.com/role: role-arn
     labels: {}
-    
-  ## Directly attach Volume
-    volumeMounts:
-      - name: apmsocketpath
-        mountPath: /var/run/datadog
-  volumes:
-    - hostPath:
-        path: /var/run/datadog/
-      name: apmsocketpath
-      
   affinity:
     # use of simple rule
     affinityRule: "ShouldBeOnDifferentNode"

--- a/incubator/monochart/values.yaml
+++ b/incubator/monochart/values.yaml
@@ -103,15 +103,6 @@ deployment:
     labels: {}
     # command:
     args: []
-    
-    volumeMounts: []
-    # - name: apmsocketpath
-    #   mountPath: /var/run/datadog
-    
-  volumes: []
-  # - name: apmsocketpath
-  #   hostPath:
-  #     path: /var/run/datadog/
 
 statefulset:
   enabled: false


### PR DESCRIPTION
This reverts commit 61ffa1b0f67e3e6e6efe4e9def6bed2337b11e06.

## what
* I Merged a PR #273 without updating Chart.yaml

## why
* Versioning isn't automatic, we don't want to override 0.26.0

