### PR TITLE
Monochart support tolerance

### DIFF
--- a/incubator/monochart/Chart.yaml
+++ b/incubator/monochart/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A declarative helm chart for deploying common types of services on Kubernetes
 name: monochart
-version: 0.27.0
-appVersion: 0.27.0
+version: 0.28.0
+appVersion: 0.28.0
 home: https://github.com/cloudposse/charts/tree/master/incubator/monochart
 icon: https://raw.githubusercontent.com/cloudposse/charts/master/incubator/monochart/logo.png
 maintainers:

--- a/incubator/monochart/templates/_helpers.tpl
+++ b/incubator/monochart/templates/_helpers.tpl
@@ -160,3 +160,71 @@ The pod anti-affinity rule to prefer not to be scheduled onto a node if that nod
     topologyKey: "kubernetes.io/hostname"
 {{- end -}}
 
+{{/*
+The affinity
+*/}}
+{{- define "monochart.affinity" -}}
+{{- if .Values.affinity }}
+affinity:
+{{- if or .Values.affinity.podAntiAffinity (eq .Values.affinity.affinityRule "ShouldBeOnDifferentNode") }}
+	podAntiAffinity:
+		preferredDuringSchedulingIgnoredDuringExecution:
+{{- if .Values.affinity.podAntiAffinity }}
+{{- if .Values.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution }}
+{{- with .Values.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution }}
+{{ toYaml . | indent 6 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if eq .Values.affinity.affinityRule "ShouldBeOnDifferentNode" }}
+{{- include "monochart.affinityRule.ShouldBeOnDifferentNode" . | nindent 6 }}
+{{- end }}
+{{- end }}
+{{- if .Values.affinity.podAffinity }}
+	podAffinity:
+		requiredDuringSchedulingIgnoredDuringExecution:
+{{- with .Values.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution }}
+{{ toYaml . | indent 6 }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- end -}}
+
+{{/*
+The nodeSelector
+*/}}
+{{- define "monochart.nodeSelector" -}}
+- weight: 100
+  podAffinityTerm:
+    labelSelector:
+      matchExpressions:
+      - key: app
+        operator: In
+        values:
+        - {{ include "common.name" . }}
+      - key: release
+        operator: In
+        values:
+        - {{ .Release.Name | quote }}
+    topologyKey: "kubernetes.io/hostname"
+{{- end -}}
+
+{{/*
+The tolerations
+*/}}
+{{- define "monochart.tolerations" -}}
+- weight: 100
+  podAffinityTerm:
+    labelSelector:
+      matchExpressions:
+      - key: app
+        operator: In
+        values:
+        - {{ include "common.name" . }}
+      - key: release
+        operator: In
+        values:
+        - {{ .Release.Name | quote }}
+    topologyKey: "kubernetes.io/hostname"
+{{- end -}}

--- a/incubator/monochart/templates/deployment.yaml
+++ b/incubator/monochart/templates/deployment.yaml
@@ -47,30 +47,9 @@ spec:
 {{- if index .Values "serviceAccountName" }}
       serviceAccountName: {{ .Values.serviceAccountName }}
 {{- end }}
-{{- if .Values.deployment.affinity }}
-      affinity:
-{{- if or .Values.deployment.affinity.podAntiAffinity (eq .Values.deployment.affinity.affinityRule "ShouldBeOnDifferentNode") }}
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-{{- if .Values.deployment.affinity.podAntiAffinity }}
-{{- if .Values.deployment.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution }}
-{{- with .Values.deployment.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution }}
-{{ toYaml . | indent 10 }}
-{{- end }}
-{{- end }}
-{{- end }}
-{{- if eq .Values.deployment.affinity.affinityRule "ShouldBeOnDifferentNode" }}
-{{- include "monochart.affinityRule.ShouldBeOnDifferentNode" . | nindent 10 }}
-{{- end }}
-{{- end }}
-{{- if .Values.deployment.affinity.podAffinity }}
-        podAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-{{- with .Values.deployment.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution }}
-{{ toYaml . | indent 10 }}
-{{- end }}
-{{- end }}
-{{- end }}
+{{- include "monochart.affinity" . | nindent 6 }}
+{{- include "monochart.nodeSelector" . | nindent 6 }}
+{{- include "monochart.tolerations" . | nindent 6 }}
       containers:
       - name: {{ .Release.Name }}
         image: {{ required "image.repository is required!" .Values.image.repository }}:{{ required "image.tag is required!" .Values.image.tag }}

--- a/incubator/monochart/values.yaml
+++ b/incubator/monochart/values.yaml
@@ -79,6 +79,55 @@ env: {}
 #     secret: kubernetes-secret-name
 #     key: key-name-in-secret
 
+nodeSelector: {}
+#  disktype: ssd
+
+tolerations: []
+#  - key: "key1"
+#    operator: "Equal"
+#    value: "value1"
+#    effect: "NoSchedule"
+
+affinity: {}
+#  nodeAffinity:
+#    requiredDuringSchedulingIgnoredDuringExecution:
+#      nodeSelectorTerms:
+#        - matchExpressions:
+#            - key: kubernetes.io/e2e-az-name
+#              operator: In
+#              values:
+#                - e2e-az1
+#                - e2e-az2
+#    preferredDuringSchedulingIgnoredDuringExecution:
+#      - weight: 1
+#        preference:
+#          matchExpressions:
+#            - key: custom-key
+#              operator: In
+#              values:
+#                - custom-value
+#
+#    podAffinity:
+#      requiredDuringSchedulingIgnoredDuringExecution:
+#        - labelSelector:
+#            matchExpressions:
+#              - key: security
+#                operator: In
+#                values:
+#                  - S1
+#          topologyKey: topology.kubernetes.io/zone
+#    podAntiAffinity:
+#      preferredDuringSchedulingIgnoredDuringExecution:
+#        - weight: 100
+#          podAffinityTerm:
+#            labelSelector:
+#              matchExpressions:
+#                - key: security
+#                  operator: In
+#                  values:
+#                    - S2
+#            topologyKey: topology.kubernetes.io/zone
+
 deployment:
   enabled: false
   ## Pods replace strategy
@@ -112,6 +161,55 @@ deployment:
   # - name: apmsocketpath
   #   hostPath:
   #     path: /var/run/datadog/
+
+  nodeSelector: {}
+  #  disktype: ssd
+
+  tolerations: []
+  #  - key: "key1"
+  #    operator: "Equal"
+  #    value: "value1"
+  #    effect: "NoSchedule"
+
+  affinity: {}
+  #  nodeAffinity:
+  #    requiredDuringSchedulingIgnoredDuringExecution:
+  #      nodeSelectorTerms:
+  #        - matchExpressions:
+  #            - key: kubernetes.io/e2e-az-name
+  #              operator: In
+  #              values:
+  #                - e2e-az1
+  #                - e2e-az2
+  #    preferredDuringSchedulingIgnoredDuringExecution:
+  #      - weight: 1
+  #        preference:
+  #          matchExpressions:
+  #            - key: custom-key
+  #              operator: In
+  #              values:
+  #                - custom-value
+  #
+  #    podAffinity:
+  #      requiredDuringSchedulingIgnoredDuringExecution:
+  #        - labelSelector:
+  #            matchExpressions:
+  #              - key: security
+  #                operator: In
+  #                values:
+  #                  - S1
+  #          topologyKey: topology.kubernetes.io/zone
+  #    podAntiAffinity:
+  #      preferredDuringSchedulingIgnoredDuringExecution:
+  #        - weight: 100
+  #          podAffinityTerm:
+  #            labelSelector:
+  #              matchExpressions:
+  #                - key: security
+  #                  operator: In
+  #                  values:
+  #                    - S2
+  #            topologyKey: topology.kubernetes.io/zone
 
 statefulset:
   enabled: false
@@ -150,6 +248,55 @@ statefulset:
   #   labels:
   #     name: value
 
+  nodeSelector: {}
+  #  disktype: ssd
+
+  tolerations: []
+  #  - key: "key1"
+  #    operator: "Equal"
+  #    value: "value1"
+  #    effect: "NoSchedule"
+
+  affinity: {}
+  #  nodeAffinity:
+  #    requiredDuringSchedulingIgnoredDuringExecution:
+  #      nodeSelectorTerms:
+  #        - matchExpressions:
+  #            - key: kubernetes.io/e2e-az-name
+  #              operator: In
+  #              values:
+  #                - e2e-az1
+  #                - e2e-az2
+  #    preferredDuringSchedulingIgnoredDuringExecution:
+  #      - weight: 1
+  #        preference:
+  #          matchExpressions:
+  #            - key: custom-key
+  #              operator: In
+  #              values:
+  #                - custom-value
+  #
+  #    podAffinity:
+  #      requiredDuringSchedulingIgnoredDuringExecution:
+  #        - labelSelector:
+  #            matchExpressions:
+  #              - key: security
+  #                operator: In
+  #                values:
+  #                  - S1
+  #          topologyKey: topology.kubernetes.io/zone
+  #    podAntiAffinity:
+  #      preferredDuringSchedulingIgnoredDuringExecution:
+  #        - weight: 100
+  #          podAffinityTerm:
+  #            labelSelector:
+  #              matchExpressions:
+  #                - key: security
+  #                  operator: In
+  #                  values:
+  #                    - S2
+  #            topologyKey: topology.kubernetes.io/zone
+
 daemonset:
   enabled: false
   ## Pods replace strategy
@@ -175,6 +322,56 @@ daemonset:
     # command:
     args: []
 
+  nodeSelector: {}
+  #  disktype: ssd
+
+  tolerations: []
+  #  - key: "key1"
+  #    operator: "Equal"
+  #    value: "value1"
+  #    effect: "NoSchedule"
+
+  affinity: {}
+  #  nodeAffinity:
+  #    requiredDuringSchedulingIgnoredDuringExecution:
+  #      nodeSelectorTerms:
+  #        - matchExpressions:
+  #            - key: kubernetes.io/e2e-az-name
+  #              operator: In
+  #              values:
+  #                - e2e-az1
+  #                - e2e-az2
+  #    preferredDuringSchedulingIgnoredDuringExecution:
+  #      - weight: 1
+  #        preference:
+  #          matchExpressions:
+  #            - key: custom-key
+  #              operator: In
+  #              values:
+  #                - custom-value
+  #
+  #    podAffinity:
+  #      requiredDuringSchedulingIgnoredDuringExecution:
+  #        - labelSelector:
+  #            matchExpressions:
+  #              - key: security
+  #                operator: In
+  #                values:
+  #                  - S1
+  #          topologyKey: topology.kubernetes.io/zone
+  #    podAntiAffinity:
+  #      preferredDuringSchedulingIgnoredDuringExecution:
+  #        - weight: 100
+  #          podAffinityTerm:
+  #            labelSelector:
+  #              matchExpressions:
+  #                - key: security
+  #                  operator: In
+  #                  values:
+  #                    - S2
+  #            topologyKey: topology.kubernetes.io/zone
+
+
 job:
   default:
     enabled: false
@@ -197,6 +394,55 @@ job:
       labels: {}
       # command:
       args: []
+
+    nodeSelector: {}
+    #  disktype: ssd
+
+    tolerations: []
+    #  - key: "key1"
+    #    operator: "Equal"
+    #    value: "value1"
+    #    effect: "NoSchedule"
+
+    affinity: {}
+    #  nodeAffinity:
+    #    requiredDuringSchedulingIgnoredDuringExecution:
+    #      nodeSelectorTerms:
+    #        - matchExpressions:
+    #            - key: kubernetes.io/e2e-az-name
+    #              operator: In
+    #              values:
+    #                - e2e-az1
+    #                - e2e-az2
+    #    preferredDuringSchedulingIgnoredDuringExecution:
+    #      - weight: 1
+    #        preference:
+    #          matchExpressions:
+    #            - key: custom-key
+    #              operator: In
+    #              values:
+    #                - custom-value
+    #
+    #    podAffinity:
+    #      requiredDuringSchedulingIgnoredDuringExecution:
+    #        - labelSelector:
+    #            matchExpressions:
+    #              - key: security
+    #                operator: In
+    #                values:
+    #                  - S1
+    #          topologyKey: topology.kubernetes.io/zone
+    #    podAntiAffinity:
+    #      preferredDuringSchedulingIgnoredDuringExecution:
+    #        - weight: 100
+    #          podAffinityTerm:
+    #            labelSelector:
+    #              matchExpressions:
+    #                - key: security
+    #                  operator: In
+    #                  values:
+    #                    - S2
+    #            topologyKey: topology.kubernetes.io/zone
 
 cronjob:
   default:
@@ -225,6 +471,55 @@ cronjob:
       labels: {}
       # command:
       args: []
+
+    nodeSelector: {}
+    #  disktype: ssd
+
+    tolerations: []
+    #  - key: "key1"
+    #    operator: "Equal"
+    #    value: "value1"
+    #    effect: "NoSchedule"
+
+    affinity: {}
+    #  nodeAffinity:
+    #    requiredDuringSchedulingIgnoredDuringExecution:
+    #      nodeSelectorTerms:
+    #        - matchExpressions:
+    #            - key: kubernetes.io/e2e-az-name
+    #              operator: In
+    #              values:
+    #                - e2e-az1
+    #                - e2e-az2
+    #    preferredDuringSchedulingIgnoredDuringExecution:
+    #      - weight: 1
+    #        preference:
+    #          matchExpressions:
+    #            - key: custom-key
+    #              operator: In
+    #              values:
+    #                - custom-value
+    #
+    #    podAffinity:
+    #      requiredDuringSchedulingIgnoredDuringExecution:
+    #        - labelSelector:
+    #            matchExpressions:
+    #              - key: security
+    #                operator: In
+    #                values:
+    #                  - S1
+    #          topologyKey: topology.kubernetes.io/zone
+    #    podAntiAffinity:
+    #      preferredDuringSchedulingIgnoredDuringExecution:
+    #        - weight: 100
+    #          podAffinityTerm:
+    #            labelSelector:
+    #              matchExpressions:
+    #                - key: security
+    #                  operator: In
+    #                  values:
+    #                    - S2
+    #            topologyKey: topology.kubernetes.io/zone
 
 service:
   enabled: false


### PR DESCRIPTION
## what
* Added support `tolerations`
* Added support `nodeSelector`
* Added support `affinity`

## why
* Provide ability for scheduling pod rules

## references
* https://kubernetes.io/docs/concepts/scheduling-eviction/