### PR TITLE
Fix invalid template when using hostAliases

### DIFF
--- a/incubator/monochart/templates/deployment.yaml
+++ b/incubator/monochart/templates/deployment.yaml
@@ -95,7 +95,7 @@ spec:
 {{- end }}
       {{- with .Values.deployment.pod.hostAliases }}
       hostAliases:
-        {{- toYaml . | indent 8 }}
+{{ toYaml . | indent 8 }}
       {{- end }}
     {{- if or .Values.dockercfg.enabled .Values.image.pullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
## what
* Update to monochart deployment, where invalid yaml is generated when using hostAliases

## why
* The newline was being removed after `hostAliases` 

## references
* none
